### PR TITLE
Added object modified event

### DIFF
--- a/src/collective/cover/tiles/configure.zcml
+++ b/src/collective/cover/tiles/configure.zcml
@@ -166,4 +166,6 @@
     factory="collective.cover.tiles.permissions.TilesPermissions"
     />
 
+ <subscriber handler=".handlers.notifyModified" />
+
 </configure>

--- a/src/collective/cover/tiles/handlers.py
+++ b/src/collective/cover/tiles/handlers.py
@@ -1,0 +1,11 @@
+# -*- coding: UTF-8 -*-
+from zope.component import adapter
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from plone.tiles.interfaces import ITile
+
+
+@adapter(ITile, IObjectModifiedEvent)
+def notifyModified(tile, event):
+    # Make sure the page's modified date gets updated, necessary in cache purge
+    # cases by eg
+    tile.__parent__.notifyModified()


### PR DESCRIPTION
Make sure the page's modified date gets updated, necessary in cache purge cases by eg
