### PR TITLE
If columns don't fit in grid system, mark them with a class

### DIFF
--- a/src/collective/cover/layout.py
+++ b/src/collective/cover/layout.py
@@ -247,4 +247,7 @@ class Deco16Grid (grok.GlobalUtility):
             width = column['data']['column-size'] if 'data' in column else 1
             column['class'] = self.column_class + ' ' + (w + str(width)) + ' ' + (p + str(offset))
             offset = offset + width
+            if offset > self.ncolumns:
+                column['class'] += ' overflowing'
+
         return columns

--- a/src/collective/cover/tests/test_layout.py
+++ b/src/collective/cover/tests/test_layout.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from collective.cover.interfaces import IGridSystem
 from collective.cover.testing import INTEGRATION_TESTING
 from plone.dexterity.utils import createContentInContainer
-from zope.component import queryMultiAdapter
+from zope.component import queryMultiAdapter, getUtility
 
+import copy
 import unittest
 
 
@@ -28,3 +30,102 @@ class LayoutTestCase(unittest.TestCase):
         for i in range(16):
             uuid = view()
             self.assertFalse(uuid[0].isdigit())
+
+
+class Deco16GridTestCase(unittest.TestCase):
+    layer = INTEGRATION_TESTING
+
+    def test_empty(self):
+        """Do-nothing case does nothing"""
+        self.assertEqual(self.doTransform([]), [])
+
+    def test_overflow(self):
+        """Overflowing row marks items as such"""
+        self.assertEqual(
+            self.doTransform([{u'type': u'row', 'children': [
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+            ]}]),
+            [{u'type': u'row', 'class': 'row', 'children': [
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-0'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-4'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-8'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-12'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-16 overflowing'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-20 overflowing'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-24 overflowing'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-28 overflowing'},
+            ]}],
+        )
+
+        # Item is half-inside grid is still overflowing
+        self.assertEqual(
+            self.doTransform([{u'type': u'row', 'children': [
+                {u'type': u'group',
+                 'data': {u'column-size': 15, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 2, u'layout-type': u'column'}},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'}},
+            ]}]),
+            [{u'type': u'row', 'class': 'row', 'children': [
+                {u'type': u'group',
+                 'data': {u'column-size': 15, u'layout-type': u'column'},
+                 'class': 'cell width-15 position-0'},
+                {u'type': u'group',
+                 'data': {u'column-size': 2, u'layout-type': u'column'},
+                 'class': 'cell width-2 position-15 overflowing'},
+                {u'type': u'group',
+                 'data': {u'column-size': 4, u'layout-type': u'column'},
+                 'class': 'cell width-4 position-17 overflowing'},
+            ]}],
+        )
+
+        # Items that are too big are too big
+        self.assertEqual(
+            self.doTransform([{u'type': u'row', 'children': [
+                {u'type': u'group',
+                 'data': {u'column-size': 20, u'layout-type': u'column'}},
+            ]}]),
+            [{u'type': u'row', 'class': 'row', 'children': [
+                {u'type': u'group',
+                 'data': {u'column-size': 20, u'layout-type': u'column'},
+                 'class': 'cell width-20 position-0 overflowing'},
+            ]}],
+        )
+
+    def doTransform(self, layout):
+        dgrid = getUtility(IGridSystem, name='deco16_grid')
+        newlayout = copy.deepcopy(layout)
+        dgrid.transform(newlayout)
+        return newlayout


### PR DESCRIPTION
Don't actually remove overflowing items, mark them as such for CSS to make a decision.