### PR TITLE
jQuety 1.9 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ There's a frood who really knows where his towel is.
 - Fix for generic title for list tiles introduced in 1.0a7 (fixes `#393`_).
   [fredvd]
 
+- Use jQuery's .on instead of deprecated .live method. This allows
+  compatibility with jQuery 1.9+
+  [naro]
+
 
 1.0a7 (2014-02-04)
 ^^^^^^^^^^^^^^^^^^

--- a/src/collective/cover/static/contentchooser.js
+++ b/src/collective/cover/static/contentchooser.js
@@ -17,7 +17,7 @@ function contentSearchFilter(url) {
 
 (function ($) {
     $.fn.liveDraggable = function (opts) {
-        this.live("mouseover", function() {
+        $(document).on("mouseover", this.selector, function() {
             if (!$(this).data("init")) {
                 $(this).data("init", true).draggable(opts);
             }
@@ -55,7 +55,7 @@ $(function() {
     // Live search content tree
     coveractions.liveSearch('#contentchooser-content-trees','.item-list li','#filter-count');
 
-    $(".item-list a.next").live("click", function(e){
+    $(document).on("click", ".item-list a.next", function(e){
         $.ajax({
             url: "@@content-search",
             data: {'page': $(e.currentTarget).attr('data-page'),
@@ -67,7 +67,7 @@ $(function() {
         return false;
     });
 
-    $("#recent .contentchooser-clear").live("click", function(e){
+    $(document).on("click", "#recent .contentchooser-clear", function(e){
         $(e.currentTarget).prev().children("input").val("");
         ajaxSearchRequest.push($.ajax({
             url: portal_url + "/@@content-search",
@@ -80,7 +80,7 @@ $(function() {
         return false;
     });
 
-    $("#content-trees .contentchooser-clear").live("click", function(e){
+    $(document).on("click", "#content-trees .contentchooser-clear", function(e){
         $(e.currentTarget).prev().children("input").val("");
         coveractions.getFolderContents(portal_url, '@@jsonbytype');
         return false;
@@ -157,10 +157,11 @@ $(function() {
     $("#contentchooser-content-search").offset({'top':offset.top});
   });
 
-  $("#contentchooser-content-search .close").click(function() {
+  $("#contentchooser-content-search .close").click(function(e) {
+    e.preventDefault();
     $("#contentchooser-content-search").css("display", "none");
   });
-  $("#contentchooser-content-search #content-tree .item-list li").live("click",function(e) {
+  $(document).on("click", "#contentchooser-content-search #content-tree .item-list li", function(e) {
     e.stopPropagation();
     var child = $(this).children("ul");
     if (child.is(":visible")) {

--- a/src/collective/cover/static/cover.js
+++ b/src/collective/cover/static/cover.js
@@ -1,7 +1,7 @@
 
 (function ($) {
     $.fn.liveSortable = function (opts) {
-        this.live("mouseover", function() {
+        this.on("mouseover", function() {
             if (!$(this).data("init")) {
                 $(this).data("init", true).sortable(opts);
             }

--- a/src/collective/cover/static/layout_edit.js
+++ b/src/collective/cover/static/layout_edit.js
@@ -24,7 +24,7 @@
                 message;
             this.message = window.form_modified_message ||
                 "Discard changes? If you click OK, any changes you have made will be lost.";
-    
+
             this.execute = function(event) {
                 var save_btn = $('#btn-save');
                 if (save_btn.hasClass('modified')) {
@@ -426,7 +426,7 @@
             tile_config_manager: function(){
                 //CONFIGURATION OF THE TILE
                 //when saving the configuration of the tile save it with ajax
-                $("#configure_tile #buttons-save").live("click", function(e) {
+                $(document).on("click", "#configure_tile #buttons-save", function(e) {
                     e.preventDefault();
                     var url = $("#configure_tile").attr("action");
                     var data = $("#configure_tile").serialize();
@@ -443,14 +443,14 @@
                     return false;
                 });
                 //when canceling the configuration of the tile
-                $("#configure_tile #buttons-cancel").live("click", function(e) {
+                $(document).on("click", "#configure_tile #buttons-cancel", function(e) {
                     e.preventDefault();
                     $('#tile-configure').html('');
                     $('#tile-configure').modal('hide');
                     return false;
                 });
                 //config the tile
-                $(".config-tile-link").live("click", function(e) {
+                $(document).on("click", ".config-tile-link", function(e) {
                       e.preventDefault();
                       var url = $(this).attr("href");
                       $('#tile-configure').modal();

--- a/src/collective/cover/templates/compose.pt
+++ b/src/collective/cover/templates/compose.pt
@@ -15,7 +15,9 @@
 
     <script type="text/javascript">
       jQuery(document).ready(function() {
-        jQuery(window).unload(plone.UnlockHandler.execute);
+        if (typeof(plone) !== 'undefined') {
+          jQuery(window).unload(plone.UnlockHandler.execute);
+        }
       });
     </script>
 </metal:js>

--- a/src/collective/cover/templates/layoutedit.pt
+++ b/src/collective/cover/templates/layoutedit.pt
@@ -23,7 +23,9 @@
 
   <script type="text/javascript">
     jQuery(document).ready(function() {
-      jQuery(window).unload(plone.UnlockHandler.execute);
+      if (typeof(plone) !== 'undefined') {
+        jQuery(window).unload(plone.UnlockHandler.execute);
+      }
     });
   </script>
 


### PR DESCRIPTION
Since collective.cover has p.a.jquery=1.7.2 in dependencies, we can use .on instead of .live method.
