### PR TITLE
Use link title to show more information in content search

### DIFF
--- a/src/collective/cover/browser/contentchooser_templates/search_list.pt
+++ b/src/collective/cover/browser/contentchooser_templates/search_list.pt
@@ -12,6 +12,7 @@
               <tal:block>
                 <a tal:attributes="rel level;
                                    class string:$item_class;
+                                   title string:${node/normalized_portal_type}:${node/path};
                                    data-ct-type content_type">
                     <img tal:replace="structure item_icon/html_tag|item_icon" />
                     <span tal:content="node/Title">Selected Item Title</span>


### PR DESCRIPTION
When dealing with thousands of content items, it's not unusual to have several items from different places sharing the same title. Showing the path and content type in the link title is a simple way to provide more information to cover composers.
