### PR TITLE
Fix unpublished content disappears from tile after an anonymous user visits the cover page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a9 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Unpublished content disappears from tile after an anonymous user visits the
-  cover page (fixes `#412`_)
-  [adriana-rv]
+- Unpublished content was disappearing from the list tile after access from
+  anonymous user (fixes `#412`_).
+  [adriana-rv, hvelarde]
 
 - Allow Site Administrator role to manage Cover control panel (closes `#423`_)
   [ericof]
@@ -517,6 +517,7 @@ There's a frood who really knows where his towel is.
 .. _`#398`: https://github.com/collective/collective.cover/issues/398
 .. _`#407`: https://github.com/collective/collective.cover/issues/407
 .. _`#411`: https://github.com/collective/collective.cover/issues/411
+.. _`#412`: https://github.com/collective/collective.cover/issues/412
 .. _`#413`: https://github.com/collective/collective.cover/issues/413
 .. _`#415`: https://github.com/collective/collective.cover/issues/415
 .. _`#421`: https://github.com/collective/collective.cover/issues/421

--- a/src/collective/cover/tests/test_list_tile.py
+++ b/src/collective/cover/tests/test_list_tile.py
@@ -159,6 +159,13 @@ class ListTileTestCase(TestTileMixin, unittest.TestCase):
         # for the test user, the first 5 objects should be still there
         login(self.portal, TEST_USER_NAME)
         results = self.tile.results()
-        self.assertEqual(len(results), 0)
+        self.assertEqual(len(results), 5)
         for i in range(1, 6):
+            self.assertIn(folder[str(i)], results)
+
+        # delete one object; it should be removed from the tile also
+        api.content.delete(folder['1'])
+        results = self.tile.results()
+        self.assertEqual(len(results), 5)
+        for i in range(2, 7):
             self.assertIn(folder[str(i)], results)


### PR DESCRIPTION
Fixes #412 
