### PR TITLE
Reorder Javascript in layoutedit.pt to common sense order hoping ...

### DIFF
--- a/src/collective/cover/browser/templates/layoutedit.pt
+++ b/src/collective/cover/browser/templates/layoutedit.pt
@@ -10,7 +10,7 @@
 <metal:js fill-slot="javascript_head_slot">
   <script type="text/javascript"
           tal:define="navroot context/@@plone_portal_state/navigation_root_url"
-          tal:attributes="src string:${navroot}/++resource++collective.cover/layout_edit.js">
+          tal:attributes="src string:${navroot}/++resource++collective.cover/jss.min.js">
   </script>
   <script type="text/javascript"
           tal:define="navroot context/@@plone_portal_state/navigation_root_url"
@@ -18,7 +18,7 @@
   </script>
   <script type="text/javascript"
           tal:define="navroot context/@@plone_portal_state/navigation_root_url"
-          tal:attributes="src string:${navroot}/++resource++collective.cover/jss.min.js">
+          tal:attributes="src string:${navroot}/++resource++collective.cover/layout_edit.js">
   </script>
 
   <script type="text/javascript">


### PR DESCRIPTION
...to avoid the following occasional Javascript Error:

```
TypeError: jss is not a function
width: '98%'
 at line 313 of layout_edit.js 
```

which ends up with Layouts displaying in one line. So, the standard 'Layout A' looking like this:

![collective cover_1 0a9](https://cloud.githubusercontent.com/assets/1470021/3661859/bd9d8bf8-11c4-11e4-82b6-373651959fc2.png)

Note this seems to occur just after upgrade - leading me to suspect the problem goes away once jss.min.js is cached.  Nonetheless this seems a sensible little change that shouldn't cause problems.

See https://community.plone.org/t/new-release-of-collective-cover/187/4 for a bit more discussion
