### PR TITLE
Extend upgrade step to update the structure of all tiles inheriting from the list tile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,13 @@ There's a frood who really knows where his towel is.
 1.0a11 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Extend upgrade step to update the structure of all tiles inheriting from the list tile (fixes `#466`_).
+  Fix upgrade step to use a dict instead of a PersistentMapping.
+  [hvelarde]
+
 - Fix to show dates for results in collection tile (fixes `#463`_).
   [kcleong]
+
 - Allow to choose a custom title and description on items in a carousel tile (closes `#459`_).
   [rodfersou]
 
@@ -585,4 +590,5 @@ There's a frood who really knows where his towel is.
 .. _`#449`: https://github.com/collective/collective.cover/issues/449
 .. _`#459`: https://github.com/collective/collective.cover/issues/459
 .. _`#463`: https://github.com/collective/collective.cover/issues/463
+.. _`#466`: https://github.com/collective/collective.cover/issues/466
 .. _`PloneFormGen`: https://pypi.python.org/pypi/Products.PloneFormGen

--- a/src/collective/cover/tests/test_upgrades.py
+++ b/src/collective/cover/tests/test_upgrades.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from collective.cover.config import DEFAULT_GRID_SYSTEM
 from collective.cover.testing import INTEGRATION_TESTING
-from persistent.mapping import PersistentMapping
 from plone import api
 from plone.registry.interfaces import IRegistry
 from plone.tiles.interfaces import ITileDataManager
@@ -259,7 +258,7 @@ class Upgrade9to10TestCase(UpgradeTestCaseBase):
         self._do_upgrade_step(step)
         old_data = ITileDataManager(tile).get()
         self.assertFalse(isinstance(old_data['uuids'], list))
-        self.assertTrue(isinstance(old_data['uuids'], PersistentMapping))
+        self.assertTrue(isinstance(old_data['uuids'], dict))
         self.assertEqual(old_data['uuids']['uuid1']['order'], u'0')
         self.assertEqual(old_data['uuids']['uuid2']['order'], u'2')
         self.assertEqual(old_data['uuids']['uuid3']['order'], u'1')

--- a/src/collective/cover/upgrades/__init__.py
+++ b/src/collective/cover/upgrades/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from collective.cover.config import PROJECTNAME
 from collective.cover.controlpanel import ICoverSettings
-from persistent.mapping import PersistentMapping
 from plone import api
 from plone.registry.interfaces import IRegistry
 from plone.tiles.interfaces import ITileDataManager
@@ -117,20 +116,37 @@ def change_configlet_permissions(context):
 
 
 def upgrade_carousel_tiles_custom_url(context):
+    """Update structure of tiles inheriting from the list tile."""
+
+    def get_tiles_to_update():
+        """Return a list of all tiles inheriting from the list tile."""
+        from collective.cover.tiles.list import IListTile
+        from plone.tiles.interfaces import ITileType
+        from zope.component import getUtility
+        from zope.schema.interfaces import IVocabularyFactory
+        name = 'collective.cover.EnabledTiles'
+        enabled_tiles = getUtility(IVocabularyFactory, name)(context)
+        tiles_to_update = []
+        for i in enabled_tiles:
+            tile = getUtility(ITileType, i.value)
+            if issubclass(tile.schema, IListTile):
+                tiles_to_update.append(i.value)
+        return tiles_to_update
+
     # Get covers
     covers = context.portal_catalog(portal_type='collective.cover.content')
-    logger.info('About to update %s covers' % len(covers))
+    logger.info('About to update {0} objects'.format(len(covers)))
+    tiles_to_update = get_tiles_to_update()
+    logger.info('{0} tile types will be updated ({1})'.format(
+        len(tiles_to_update), ', '.join(tiles_to_update)))
     for cover in covers:
         obj = cover.getObject()
-        tile_ids = obj.list_tiles(types=[
-            u'collective.cover.carousel',
-            u'collective.cover.list'
-        ])
+        tile_ids = obj.list_tiles(types=tiles_to_update)
         for tile_id in tile_ids:
             tile = obj.get_tile(tile_id)
             old_data = ITileDataManager(tile).get()
             uuids = old_data['uuids']
-            if isinstance(uuids, PersistentMapping):
+            if isinstance(uuids, dict):
                 # This tile is fixed, carry on
                 logger.info(
                     'Tile %s at %s was already updated' %
@@ -145,11 +161,11 @@ def upgrade_carousel_tiles_custom_url(context):
                 )
                 continue
 
-            new_data = PersistentMapping()
+            new_data = dict()
             order = 0
             for uuid in uuids:
                 if uuid not in new_data.keys():
-                    entry = PersistentMapping()
+                    entry = dict()
                     entry[u'order'] = unicode(order)
                     new_data[uuid] = entry
                     order += 1


### PR DESCRIPTION
Fix upgrade step to use a dict instead of a PersistentMapping.

fixes #466
refs. #467
