### PR TITLE
Include a trigger to init patterns in case plone.app.widgets is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ There's a frood who really knows where his towel is.
 1.0a11 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- If mockup is present and new widgets are used, call the scan function from
+  the mockup-registry to initialize them.
+  [frapell]
+
 - Extend upgrade step to update the structure of all tiles inheriting from the list tile (fixes `#466`_).
   Fix upgrade step to use a dict instead of a PersistentMapping.
   [hvelarde]

--- a/src/collective/cover/static/cover.js
+++ b/src/collective/cover/static/cover.js
@@ -49,6 +49,25 @@ function TitleMarkupSetup(){
     removeObjFromTile();
 }
 
+function initPatterns(selector) {
+    // In case plone.app.widgets is installed, we want to initialize patterns
+    // like for instance, TinyMCE
+    try {
+        require('mockup-registry').scan($(selector));
+        $(selector+ " input#buttons-save").on("click", function (){
+            tinyMCE.triggerSave();
+        });
+        // Apparently JS devs love to z-index always at 9999. This conflicts
+        // with TinyMCE overlays
+        $(".overlay").on("mouseover", function (){
+            $('div.modal-wrapper').css('z-index', "10050");
+        });
+    } catch(error) {
+        // If we are here it most probably means we don't have
+        // plone.app.widgets, so just ignore and continue
+    }
+}
+
 $(document).ready(function() {
     var root = typeof exports !== "undefined" && exports !== null ? exports : this;
     root.reloadTypes = ['collective.cover.carousel'];

--- a/src/collective/cover/tiles/templates/tileformlayout.pt
+++ b/src/collective/cover/tiles/templates/tileformlayout.pt
@@ -3,3 +3,6 @@
 
     <span tal:replace="structure view/contents" />
 </div>
+<script>
+    initPatterns('div.tile-content');
+</script>


### PR DESCRIPTION
If plone.app.widgets is installed and patterns are being used, call the registry scan to initialize them when the edit form popup is opened for a tile