### PR TITLE
Don't ignore dropped objects on carousel tiles if the image is added to ...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a11 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Don't ignore dropped objects on carousel tiles if the image is added to the object using a Dexterity behavior. (fixes '#473`_`).
+  [fredvd]
+
 - Allow new empty carousel tiles to be edited in compose mode. (fixes `#472`_).
   [fredvd]
 

--- a/src/collective/cover/tiles/carousel.py
+++ b/src/collective/cover/tiles/carousel.py
@@ -58,16 +58,13 @@ class CarouselTile(ListTile):
     def populate_with_object(self, obj):
         """Add an object to the carousel. This method will append new
         elements to the already existing list of items. If the object
-        does not have an image associated, it will not be included.
+        does not have an image associated, it will not be included and silently
+        ignored.
 
         :param uuids: The list of objects' UUIDs to be used
         :type uuids: List of strings
         """
-        try:
-            image_size = obj.restrictedTraverse('@@images').getImageSize()
-        except:
-            image_size = None
-        if not image_size:
+        if not self._has_image_field(obj):
             return
         super(CarouselTile, self).populate_with_object(obj)
 

--- a/src/collective/cover/tiles/carousel.py
+++ b/src/collective/cover/tiles/carousel.py
@@ -58,8 +58,8 @@ class CarouselTile(ListTile):
     def populate_with_object(self, obj):
         """Add an object to the carousel. This method will append new
         elements to the already existing list of items. If the object
-        does not have an image associated, it will not be included and silently
-        ignored.
+        does not have an image associated, it will not be included and
+        silently ignored.
 
         :param uuids: The list of objects' UUIDs to be used
         :type uuids: List of strings


### PR DESCRIPTION
...the object using a Dexterity behavior. (fixes '#473`_`).