### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/collective/collective.cover.png?label=ready&title=Ready 
+ :target: https://waffle.io/collective/collective.cover
+ :alt: 'Stories in Ready'
 ****************
 collective.cover
 ****************


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/collective/collective.cover

This was requested by a real person (user hvelarde) on waffle.io, we're not trying to spam you.