### PR TITLE
May have fixed randomly failing Locked Cover test

### DIFF
--- a/src/collective/cover/tests/cover.robot
+++ b/src/collective/cover/tests/cover.robot
@@ -8,6 +8,8 @@ Variables  plone/app/testing/interfaces.py
 ${PORT} =  55001
 ${ZOPE_URL} =  http://localhost:${PORT}
 ${PLONE_URL} =  ${ZOPE_URL}/plone
+${ALT_ZOPE_HOST} =  127.0.0.1
+${ALT_PLONE_URL} =  http://${ALT_ZOPE_HOST}:${PORT}/plone
 ${BROWSER} =  Firefox
 
 ${title_selector} =  input#form-widgets-IBasic-title

--- a/src/collective/cover/tests/test_locked_cover.robot
+++ b/src/collective/cover/tests/test_locked_cover.robot
@@ -9,8 +9,6 @@ Suite Teardown  Close all browsers
 
 *** Variables ***
 
-${ALT_ZOPE_HOST}  127.0.0.1
-${ALT_PLONE_URL}  http://${ALT_ZOPE_HOST}:${ZOPE_PORT}/${PLONE_SITE_ID}
 ${LOCKED_MESSAGE}  This item was locked by admin 1 minute ago.
 ${basic_tile_location}  'collective.cover.basic'
 ${document_selector}  .ui-draggable .contenttype-document
@@ -19,10 +17,8 @@ ${tile_selector}  div.tile-container div.tile
 *** Test Cases ***
 
 Test Locked Cover
-    [Tags]  Expected Failure
-
     Log in as site owner
-    Goto Homepage
+    Click Link  link=Home
     Create Cover  My Cover  Description
     Edit Cover Layout
 
@@ -43,7 +39,7 @@ Test Locked Cover
     # open a new browser to simulate a 2-user interaction
     Open Browser  ${ALT_PLONE_URL}
     Enable Autologin as  Site Administrator
-    Goto Homepage
+    Go to  ${ALT_PLONE_URL}
     Click Link  link=My Cover
     Page Should Contain  Locked  ${LOCKED_MESSAGE}
 


### PR DESCRIPTION
This was causing the following error when running locally, which seems to be related to a [robotframework bug regarding use of imported variables in variable table](https://code.google.com/p/robotframework/issues/detail?id=561). 

    13/17 (76.5%)[ ERROR ] Error in file '.../collective.cover/src/collective/cover/tests/test_locked_cover.robot' in table 'Variables': Setting variable '${ALT_PLONE_URL}' failed: Non-existing variable '${ZOPE_PORT}'.

Fixed for me by moving definitions. So maybe Travis & my set up are both on older versions of robotframework?  My versions are:

    robotframework = 2.7.6
    robotframework-selenium2library = 1.1.0
