### PR TITLE
Add pinnig on collective.js.bootstrap to 2.3.1.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,7 @@ To enable this package in a buildout-based installation:
 
     [versions]
     ...
+    collective.js.bootstrap = 2.3.1.1
     collective.js.jqueryui = 1.8.16.9
     plone.app.jquery = 1.7.2
     plone.app.jquerytools = 1.5.7

--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -1,4 +1,5 @@
 [versions]
+collective.js.bootstrap = 2.3.1.1
 collective.js.jqueryui = 1.8.16.9
 plone.app.blocks = 1.1.1
 plone.app.drafts = 1.0a2


### PR DESCRIPTION
Avoid depending explicitly on ``plone.app.jquery = 1.8.3``