### PR TITLE
Issue 495 - carousel compose edit window

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ There's a frood who really knows where his towel is.
 1.0a11 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix the carousel compose edit widget when items have been added that are now expired.
+  List the items with a red border and a warning text.
+  This only fixes listing expired content for non-managers (like using having the Editor rol) in compose mode, it doesn't change visibility of items when viewing.
+  [fredvd]
+
 - Do not purge fields in registry.xml to avoid overwriting information at reinstall time (fixes `#465`_).
   [hvelarde]
 
@@ -633,5 +638,6 @@ There's a frood who really knows where his towel is.
 .. _`#476`: https://github.com/collective/collective.cover/issues/476
 .. _`#493`: https://github.com/collective/collective.cover/issues/493
 .. _`#494`: https://github.com/collective/collective.cover/issues/494
+.. _`#495`: https://github.com/collective/collective.cover/issues/495
 .. _`#504`: https://github.com/collective/collective.cover/issues/504
 .. _`PloneFormGen`: https://pypi.python.org/pypi/Products.PloneFormGen

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -13,6 +13,7 @@ the following people:
 - Denis Krienbühl
 - Érico Andrei
 - Franco Pellegrini
+- Fred van Dijk
 - Fulvio Casali
 - Giorgio Borelli
 - Gonzalo Almeida

--- a/src/collective/cover/static/cover.css
+++ b/src/collective/cover/static/cover.css
@@ -150,7 +150,7 @@ table.invisible{visibility:visible;}
     box-shadow: 0 5px 10px #C3C3C3;
 }
 
-.textline-sortable-element.expired { 
+.textline-sortable-element.expired {
     border: 1px solid red;
 }
 .textline-sortable-element .tileProperties .tileExpired {

--- a/src/collective/cover/static/cover.css
+++ b/src/collective/cover/static/cover.css
@@ -149,3 +149,11 @@ table.invisible{visibility:visible;}
     -webkit-box-shadow: 0 5px 10px #C3C3C3;
     box-shadow: 0 5px 10px #C3C3C3;
 }
+
+.textline-sortable-element.expired { 
+    border: 1px solid red;
+}
+.textline-sortable-element .tileProperties .tileExpired {
+  font-weight: bold;
+  color: red;
+}

--- a/src/collective/cover/utils.py
+++ b/src/collective/cover/utils.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-
-import uuid
 from plone import api
 
+import uuid
+
+
 def assign_tile_ids(layout, override=True):
-    """
-    This function takes a dict, and it will recursively traverse it and assign
-    sha-hashed ids so we are pretty sure they are unique among them
+    """Recursively traverse a dict describing a layout and assign
+    sha-hashed ids to the tiles so we are pretty sure they are unique
+    among them.
     """
 
     for elem in layout:
@@ -20,28 +21,26 @@ def assign_tile_ids(layout, override=True):
 
 
 def uuidToObject(uuid):
-    """Given a UUID, attempt to return a content object. Will return
-    None if the UUID can't be found. 
+    """Return a content object given an UUID.
+
+    :param uuid: UUID of the object
+    :type uuid: str
+    :returns: the content object or None, if the uuid can't be found.
     """
-    
-    # Use local uuidToCatalogBrain without the inactive content filter 
+    # Use local uuidToCatalogBrain without the inactive content filter
     brain = uuidToCatalogBrain(uuid)
-    if brain is None:
-        return None
-    
-    return brain.getObject()
+    return brain.getObject() if brain else None
+
 
 def uuidToCatalogBrain(uuid):
-    """Given a UUID, attempt to return a catalog brain.
-       Copied from plone.app.uuid:utils but doesn't filter on expired items
+    """Return a catalog brain given an UUID.
+    Copied from plone.app.uuid:utils but doesn't filter on expired items.
+
+    :param uuid: UUID of the object
+    :type uuid: str
+    :returns: the catalog brain associated with the object or None,
+        if the uuid can't be found.
     """
-    
-    catalog = api.portal.get_tool(name='portal_catalog')
-    if catalog is None:
-        return None
-    
-    result = catalog(UID=uuid, show_all=1, show_inactive=1)
-    if len(result) != 1:
-        return None
-    
-    return result[0]
+    catalog = api.portal.get_tool('portal_catalog')
+    results = catalog(UID=uuid, show_all=1, show_inactive=1)
+    return results[0] if results else None

--- a/src/collective/cover/utils.py
+++ b/src/collective/cover/utils.py
@@ -25,7 +25,7 @@ def uuidToObject(uuid):
 
     :param uuid: UUID of the object
     :type uuid: str
-    :returns: the content object or None, if the uuid can't be found.
+    :returns: the content object or None, if the UUID can't be found.
     """
     # Use local uuidToCatalogBrain without the inactive content filter
     brain = uuidToCatalogBrain(uuid)
@@ -39,7 +39,7 @@ def uuidToCatalogBrain(uuid):
     :param uuid: UUID of the object
     :type uuid: str
     :returns: the catalog brain associated with the object or None,
-        if the uuid can't be found.
+        if the UUID can't be found.
     """
     catalog = api.portal.get_tool('portal_catalog')
     results = catalog(UID=uuid, show_all=1, show_inactive=1)

--- a/src/collective/cover/utils.py
+++ b/src/collective/cover/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import uuid
-
+from plone import api
 
 def assign_tile_ids(layout, override=True):
     """
@@ -17,3 +17,31 @@ def assign_tile_ids(layout, override=True):
             children = elem.get('children')
             if children:
                 assign_tile_ids(children, override)
+
+
+def uuidToObject(uuid):
+    """Given a UUID, attempt to return a content object. Will return
+    None if the UUID can't be found. 
+    """
+    
+    # Use local uuidToCatalogBrain without the inactive content filter 
+    brain = uuidToCatalogBrain(uuid)
+    if brain is None:
+        return None
+    
+    return brain.getObject()
+
+def uuidToCatalogBrain(uuid):
+    """Given a UUID, attempt to return a catalog brain.
+       Copied from plone.app.uuid:utils but doesn't filter on expired items
+    """
+    
+    catalog = api.portal.get_tool(name='portal_catalog')
+    if catalog is None:
+        return None
+    
+    result = catalog(UID=uuid, show_all=1, show_inactive=1)
+    if len(result) != 1:
+        return None
+    
+    return result[0]

--- a/src/collective/cover/utils.py
+++ b/src/collective/cover/utils.py
@@ -32,6 +32,7 @@ def uuidToObject(uuid):
     return brain.getObject() if brain else None
 
 
+# TODO: implement this directly in plone.app.uuid
 def uuidToCatalogBrain(uuid):
     """Return a catalog brain given an UUID.
     Copied from plone.app.uuid:utils but doesn't filter on expired items.
@@ -42,5 +43,7 @@ def uuidToCatalogBrain(uuid):
         if the UUID can't be found.
     """
     catalog = api.portal.get_tool('portal_catalog')
+    # XXX: should we add a check on 'Access inactive portal content'
+    #      permission before setting show_inactive?
     results = catalog(UID=uuid, show_all=1, show_inactive=1)
     return results[0] if results else None

--- a/src/collective/cover/widgets/textlines_sortable_input.pt
+++ b/src/collective/cover/widgets/textlines_sortable_input.pt
@@ -70,8 +70,9 @@ div.tileProperties textarea {
         <tal:items repeat="item view/sort_results">
           <div class="textline-sortable-element"
                tal:define="obj nocall:item/obj;
-                           uuid item/uuid"
-               tal:attributes="data-uid uuid">
+                           uuid item/uuid;
+                           isExpired python:view.isExpired(obj) and 'expired' or '';"
+               tal:attributes="data-uid uuid; class string:textline-sortable-element ${isExpired};">
             <img class="tileImage"
                  tal:define="thumbnail python:view.thumbnail(obj)"
                  tal:condition="thumbnail"
@@ -79,6 +80,9 @@ div.tileProperties textarea {
                                  width thumbnail/width;
                                  height thumbnail/height" />
             <div class="tileProperties">
+              <div class="tileExpired" tal:condition="python:isExpired == 'expired'">
+                <span i18n:translate="">This item has expired</span>
+              </div>
               <div class="tileTitle">
                 <input class="custom-title-input"
                        tal:attributes="name python:'{0}.custom_title.{1}'.format(view.name, uuid);

--- a/src/collective/cover/widgets/textlinessortable.py
+++ b/src/collective/cover/widgets/textlinessortable.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from collective.cover.widgets.interfaces import ITextLinesSortableWidget
+from collective.cover.utils import uuidToObject
 from plone import api
-from plone.app.uuid.utils import uuidToObject
 from z3c.form import interfaces
 from z3c.form import widget
 from z3c.form.browser import textlines
@@ -50,6 +50,8 @@ class TextLinesSortableWidget(textlines.TextLinesWidget):
         :type item: Content object
         :returns: The <img> tag for the scale
         """
+        if not item:
+            return None
         scales = item.restrictedTraverse('@@images')
         try:
             return scales.scale('image', 'tile')

--- a/src/collective/cover/widgets/textlinessortable.py
+++ b/src/collective/cover/widgets/textlinessortable.py
@@ -3,6 +3,8 @@
 from collective.cover.widgets.interfaces import ITextLinesSortableWidget
 from collective.cover.utils import uuidToObject
 from plone import api
+from Products.CMFPlone.utils import base_hasattr
+
 from z3c.form import interfaces
 from z3c.form import widget
 from z3c.form.browser import textlines
@@ -57,6 +59,11 @@ class TextLinesSortableWidget(textlines.TextLinesWidget):
             return scales.scale('image', 'tile')
         except:
             return None
+
+    def isExpired(self, item):
+        if base_hasattr(item, 'expires'):
+            return item.expires().isPast()
+        return False
 
     def get_custom_title(self, uuid):
         """ Returns the custom Title assigned to a specific item


### PR DESCRIPTION
This fixes the carousel edit overlay for compose when (in the mean time) expired content has been added to the carousel and the logged in user is not Manager. It doesn't change view mode of the carousel. 

Fixes #495 