### PR TITLE
Tidy custom-description-input by setting width rather than max-width

### DIFF
--- a/src/collective/cover/widgets/textlines_sortable_input.pt
+++ b/src/collective/cover/widgets/textlines_sortable_input.pt
@@ -23,9 +23,11 @@
 .tileProperties textarea {
     float: right;
 }
-div.tileProperties input,
-div.tileProperties textarea {
+div.tileProperties input {
     min-width: 65%
+}
+div.tileProperties textarea {
+    width: 65%
 }
 .tileProperties span {
     margin-right: .5em;


### PR DESCRIPTION
Tidy "Edit Cycle2 Carousel Tile" view so description box lines up nicely with Title & URL box.

