### PR TITLE
Filter CSS class vocabularies for column / row class choosers introduced in #513

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -257,3 +257,38 @@ If you switch from the default 16-column Deco grid to another grid with a differ
 these saved layouts will still contain a 16-column width and this can mock up your design in small ways.
 In that case,
 make sure you clear the default cover layouts and/or save your own layout with the correct number of columns.
+
+Row and Column Classes
+++++++++++++++++++++++
+
+``collective.cover`` enables you to set CSS classes on rows and columns in its layouts.
+These classes are those listed in the Styles field of the @@cover-settings view, which is
+also used for Tile styles.
+This does mean that rows, columns and tiles will have the same list of classes available for styling.
+If this is not satisfactory then the vocabularies ``collective.cover.RowColumnStyles`` and/or
+``collective.cover.TileStyles`` can be overridden in your own product as shown below:
+
+In **overrides.zcml**:
+
+    <utility
+        factory=".vocabularies.RowColumnStylesVocabulary"
+        provides="zope.schema.interfaces.IVocabularyFactory"
+        name="collective.cover.RowColumnStyles"
+        />
+
+**vocabularies.py**
+
+    from zope.schema.vocabulary import SimpleTerm
+    from zope.schema.vocabulary import SimpleVocabulary
+
+    class RowColumnStylesVocabulary(object):
+
+        def __call__(self, context):
+            items = []
+            items.append(SimpleTerm(value=u'row-default', title='Row Default'))
+            items.append(SimpleTerm(value=u'row-alternative', title='Row Alternative'))
+            items.append(SimpleTerm(value=u'column-default', title='Column Default'))
+            items.append(SimpleTerm(value=u'column-alternative', title='Column Alternative'))
+
+            return SimpleVocabulary(items)
+

--- a/src/collective/cover/browser/cover.py
+++ b/src/collective/cover/browser/cover.py
@@ -152,9 +152,12 @@ class LayoutEdit(grok.View):
 
     def update(self):
         self.context = aq_inner(self.context)
-        vocab = getUtility(IVocabularyFactory,
-                           'collective.cover.RowColumnStyles')
-        self.css_classes = vocab(self.context)
+        row_vocab = getUtility(IVocabularyFactory,
+                               'collective.cover.RowStyles')
+        self.row_css_classes = row_vocab(self.context)
+        column_vocab = getUtility(IVocabularyFactory,
+                                  'collective.cover.ColumnStyles')
+        self.column_css_classes = column_vocab(self.context)
         # XXX: used to lock the object when someone is editing it
         notify(EditBegunEvent(self.context))
 

--- a/src/collective/cover/browser/cover.py
+++ b/src/collective/cover/browser/cover.py
@@ -5,7 +5,6 @@ from collective.cover.controlpanel import ICoverSettings
 from collective.cover.interfaces import ICover
 from collective.cover.interfaces import IGridSystem
 from collective.cover.tiles.list import ListTile
-from collective.cover.vocabularies import TileStylesVocabulary
 from five import grok
 from plone import api
 from plone.dexterity.events import EditBegunEvent
@@ -153,7 +152,8 @@ class LayoutEdit(grok.View):
 
     def update(self):
         self.context = aq_inner(self.context)
-        vocab = getUtility(IVocabularyFactory, name="collective.cover.RowColumnStyles")
+        vocab = getUtility(IVocabularyFactory,
+                           'collective.cover.RowColumnStyles')
         self.css_classes = vocab(self.context)
         # XXX: used to lock the object when someone is editing it
         notify(EditBegunEvent(self.context))

--- a/src/collective/cover/browser/cover.py
+++ b/src/collective/cover/browser/cover.py
@@ -17,6 +17,7 @@ from Products.CMFCore.exceptions import BadRequest
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.event import notify
+from zope.schema.interfaces import IVocabularyFactory
 
 import json
 
@@ -152,7 +153,7 @@ class LayoutEdit(grok.View):
 
     def update(self):
         self.context = aq_inner(self.context)
-        vocab = TileStylesVocabulary()
+        vocab = getUtility(IVocabularyFactory, name="collective.cover.RowColumnStyles")
         self.css_classes = vocab(self.context)
         # XXX: used to lock the object when someone is editing it
         notify(EditBegunEvent(self.context))

--- a/src/collective/cover/browser/templates/layoutedit.pt
+++ b/src/collective/cover/browser/templates/layoutedit.pt
@@ -54,9 +54,18 @@
                         </p>
                         <div id="slider"></div>
                     </div>
-                    <div id="class-chooser" title="Choose Class">
+                    <div id="row-class-chooser" title="Choose Row Class">
                         <select>
-                            <tal:classes repeat="item view/css_classes">
+                            <tal:classes repeat="item view/row_css_classes">
+                                <option tal:attributes="value item/value"
+                                        tal:content="item/title">
+                                </option>
+                            </tal:classes>
+                        </select>
+                    </div>
+                    <div id="column-class-chooser" title="Choose Column Class">
+                        <select>
+                            <tal:classes repeat="item view/column_css_classes">
                                 <option tal:attributes="value item/value"
                                         tal:content="item/title">
                                 </option>

--- a/src/collective/cover/controlpanel.py
+++ b/src/collective/cover/controlpanel.py
@@ -45,8 +45,12 @@ class ICoverSettings(form.Schema):
     styles = schema.Set(
         title=_(u'Styles'),
         description=_(
-            u'Enter a list of styles to appear in the style pulldown. '
-            u'Format is title|className, one per line.'),
+            u'Enter a list of styles to appear in the style pulldowns for '
+            u'Tiles, Columns or Rows. '
+            u'Format is title|className, one per line.\n'
+            u'classNames starting with "tile-" will only be available as Tile '
+            u'classes, similarly for classNames starting "row-" and "column-".'
+        ),
         required=False,
         default=set(),
         value_type=schema.ASCIILine(title=_(u'CSS Class')),

--- a/src/collective/cover/profiles/default/registry.xml
+++ b/src/collective/cover/profiles/default/registry.xml
@@ -34,6 +34,8 @@
       <element>Border|tile-edge</element>
       <element>Dark Background|tile-dark</element>
       <element>Shadow|tile-shadow</element>
+      <element>-Column Default-|column-default</element>
+      <element>-Row Default-|row-default</element>
     </value>
   </record>
 

--- a/src/collective/cover/static/cover.css
+++ b/src/collective/cover/static/cover.css
@@ -157,3 +157,6 @@ table.invisible{visibility:visible;}
   font-weight: bold;
   color: red;
 }
+.template-cover-settings .formHelp {
+  white-space: pre;
+}

--- a/src/collective/cover/static/layout_edit.js
+++ b/src/collective/cover/static/layout_edit.js
@@ -88,7 +88,8 @@
                 self.generate_grid_css();
                 self.delete_manager();
                 self.resize_columns_manager();
-                self.class_chooser_manager();
+                self.row_class_chooser_manager();
+                self.column_class_chooser_manager();
 
                 self.tile_config_manager();
 
@@ -425,32 +426,63 @@
             },
 
             /**
-             *  Class chooser
+             *  Row Class chooser
              *
              **/
-            class_chooser_manager: function(){
-                $("#class-chooser" ).dialog({
+            row_class_chooser_manager: function(){
+                $("#row-class-chooser" ).dialog({
                     autoOpen: false
                 });
 
-                $(document).on('click', '.config-row-link, .config-column-link', function(e) {
+                $(document).on('click', '.config-row-link', function(e) {
                     e.preventDefault();
                     $target = $(this).parent();
-                    $('#class-chooser').data('target', $target);
+                    $('#row-class-chooser').data('target', $target);
                     if ($target.attr('data-css-class')) {
-                        $('#class-chooser select').val(
+                        $('#row-class-chooser select').val(
                             $target.attr('data-css-class')
                         );
                     } else {
-                        $('#class-chooser select').val('');
+                        $('#row-class-chooser select').val('');
                     }
-                    $('#class-chooser').dialog( "open" );
+                    $('#row-class-chooser').dialog( "open" );
                 });
 
-                $(document).on('change', '#class-chooser select', function(e) {
+                $(document).on('change', '#row-class-chooser select', function(e) {
                     e.preventDefault();
                     $select = $(this);
-                    $target = $('#class-chooser').data('target');
+                    $target = $('#row-class-chooser').data('target');
+                    $target.attr('data-css-class', $select.val());
+                });
+            },
+
+            /**
+             *  Column Class chooser
+             *
+             **/
+            column_class_chooser_manager: function(){
+                $("#column-class-chooser" ).dialog({
+                    autoOpen: false
+                });
+
+                $(document).on('click', '.config-column-link', function(e) {
+                    e.preventDefault();
+                    $target = $(this).parent();
+                    $('#column-class-chooser').data('target', $target);
+                    if ($target.attr('data-css-class')) {
+                        $('#column-class-chooser select').val(
+                            $target.attr('data-css-class')
+                        );
+                    } else {
+                        $('#column-class-chooser select').val('');
+                    }
+                    $('#column-class-chooser').dialog( "open" );
+                });
+
+                $(document).on('change', '#column-class-chooser select', function(e) {
+                    e.preventDefault();
+                    $select = $(this);
+                    $target = $('#column-class-chooser').data('target');
                     $target.attr('data-css-class', $select.val());
                 });
             },

--- a/src/collective/cover/tests/test_controlpanel.py
+++ b/src/collective/cover/tests/test_controlpanel.py
@@ -86,7 +86,9 @@ class RegistryTestCase(unittest.TestCase):
             set(['-Default-|tile-default',
                  'Border|tile-edge',
                  'Dark Background|tile-dark',
-                 'Shadow|tile-shadow'])
+                 'Shadow|tile-shadow',
+                 '-Column Default-|column-default',
+                 '-Row Default-|row-default'])
         )
 
     def test_grid_system_record_in_registry(self):

--- a/src/collective/cover/tests/test_layout.robot
+++ b/src/collective/cover/tests/test_layout.robot
@@ -83,13 +83,13 @@ Test Basic Layout Operations
     Click Button  id=buttons-save
     # Change row class
     Click Element  css=.config-row-link:nth-child(1)
-    Wait until element is visible  id=class-chooser
-    Select From List  css=#class-chooser select  Shadow
+    Wait until element is visible  id=row-class-chooser
+    Select From List  css=#row-class-chooser select  -Column Default-
     Click Element  css=.ui-dialog:last-child .ui-dialog-titlebar-close
     # Change column class
     Click Element  css=.config-column-link:nth-child(1)
-    Wait until element is visible  id=class-chooser
-    Select From List  css=#class-chooser select  Border
+    Wait until element is visible  id=column-class-chooser
+    Select From List  css=#column-class-chooser select  -Row Default-
     Click Element  css=.ui-dialog:last-child .ui-dialog-titlebar-close
     Save Cover Layout
 

--- a/src/collective/cover/vocabularies.py
+++ b/src/collective/cover/vocabularies.py
@@ -132,4 +132,7 @@ class TileStylesVocabulary(object):
 
         return SimpleVocabulary(items)
 
+# CSS classes for tiles and for "rows & columns". Separate declarations even
+# though they are the same means they can be overridden separately
 grok.global_utility(TileStylesVocabulary, name=u'collective.cover.TileStyles')
+grok.global_utility(TileStylesVocabulary, name=u'collective.cover.RowColumnStyles')

--- a/src/collective/cover/vocabularies.py
+++ b/src/collective/cover/vocabularies.py
@@ -101,7 +101,7 @@ grok.global_utility(AvailableContentTypesVocabulary,
                     name=u'collective.cover.AvailableContentTypes')
 
 
-class TileStylesVocabulary(object):
+class StylesVocabulary(object):
     """Creates a vocabulary with the available styles stored in the registry.
     """
     grok.implements(IVocabularyFactory)
@@ -122,17 +122,68 @@ class TileStylesVocabulary(object):
                     # make sure that default style is always first
                     if css_class == u'tile-default':
                         items.insert(0, SimpleTerm(value=css_class, title=title))
-                        with_default = True
                     else:
                         items.append(SimpleTerm(value=css_class, title=title))
 
-        # force default style if it was removed from configuration
-        if not with_default:
+        return SimpleVocabulary(items)
+
+
+class TileStylesVocabulary(object):
+    """ A vocabulary from  available styles stored in the registry,
+        with Column & Row styles filtered out.
+    """
+    grok.implements(IVocabularyFactory)
+
+    def __call__(self, context):
+        base_vocab = StylesVocabulary()
+        items = [sTerm for sTerm in base_vocab(context)
+                       if not (sTerm.value.startswith('column-') or
+                               sTerm.value.startswith('row-')) ]
+        default_item = [sTerm for sTerm in items if sTerm.value == u'tile-default']
+        if not default_item:
             items.insert(0, SimpleTerm(value=u'tile-default', title='-Default-'))
 
         return SimpleVocabulary(items)
 
+
+class RowStylesVocabulary(object):
+    """ A vocabulary from  available styles stored in the registry,
+        with Column & Tile styles filtered out.
+    """
+    grok.implements(IVocabularyFactory)
+
+    def __call__(self, context):
+        base_vocab = StylesVocabulary()
+        items = [sTerm for sTerm in base_vocab(context)
+                       if not (sTerm.value.startswith('column-') or
+                               sTerm.value.startswith('tile-')) ]
+        default_item = [sTerm for sTerm in items if sTerm.value == u'row-default']
+        if not default_item:
+            items.insert(0, SimpleTerm(value=u'row-default', title='-Row Default-'))
+
+        return SimpleVocabulary(items)
+
+
+class ColumnStylesVocabulary(object):
+    """ A vocabulary from  available styles stored in the registry,
+        with Row & Tile styles filtered out.
+    """
+    grok.implements(IVocabularyFactory)
+
+    def __call__(self, context):
+        base_vocab = StylesVocabulary()
+        items = [sTerm for sTerm in base_vocab(context)
+                       if not (sTerm.value.startswith('row-') or
+                               sTerm.value.startswith('tile-')) ]
+        default_item = [sTerm for sTerm in items if sTerm.value == u'column-default']
+        if not default_item:
+            items.insert(0, SimpleTerm(value=u'column-default', title='-Column Default-'))
+
+        return SimpleVocabulary(items)
+
+
 # CSS classes for tiles and for "rows & columns". Separate declarations even
 # though they are the same means they can be overridden separately
 grok.global_utility(TileStylesVocabulary, name=u'collective.cover.TileStyles')
-grok.global_utility(TileStylesVocabulary, name=u'collective.cover.RowColumnStyles')
+grok.global_utility(RowStylesVocabulary, name=u'collective.cover.RowStyles')
+grok.global_utility(ColumnStylesVocabulary, name=u'collective.cover.ColumnStyles')


### PR DESCRIPTION
This small change allows (for instance) people to override classes shown in the drop down list for Columns & Rows configurations.  This could be used to (for example) filter the classes from TileStylesVocabulary.

The following demonstrates a simple override for Row & Column styles once this is in place:

In **overrides.zcml**:

```
<utility
    factory=".vocabularies.RowStylesVocabulary"
    provides="zope.schema.interfaces.IVocabularyFactory"
    name="collective.cover.RowColumnStyles"
    />
```

**vocabularies.py**

```
from zope.schema.vocabulary import SimpleTerm
from zope.schema.vocabulary import SimpleVocabulary

class RowStylesVocabulary(object):

    def __call__(self, context):
        items = []
        items.insert(0, SimpleTerm(value=u'row-default', title='Row Default'))
        items.append(SimpleTerm(value=u'row-other', title='Row Other'))

        return SimpleVocabulary(items)
```
