### PR TITLE
Rationalize JS slightly for compose view

### DIFF
--- a/src/collective/cover/browser/templates/compose.pt
+++ b/src/collective/cover/browser/templates/compose.pt
@@ -10,7 +10,7 @@
 <metal:js fill-slot="javascript_head_slot">
     <script type="text/javascript"
         tal:define="navroot context/@@plone_portal_state/navigation_root_url"
-        tal:attributes="src string:${navroot}/++resource++collective.cover/cover.js">
+        tal:attributes="src string:${navroot}/++resource++collective.cover/compose.js">
     </script>
 
     <script type="text/javascript">

--- a/src/collective/cover/static/compose.js
+++ b/src/collective/cover/static/compose.js
@@ -78,7 +78,7 @@ $(document).ready(function() {
 
     TitleMarkupSetup();
 
-    $('a.edit-tile-link, a.config-tile-link').prepOverlay({
+    $('a.edit-tile-link').prepOverlay({
         subtype: 'ajax',
         filter: '.tile-content',
         formselector: '#edit_tile',


### PR DESCRIPTION
Clicks on "a.config-tile-link" are really handled [elsewhere](https://github.com/collective/collective.cover/blob/master/src/collective/cover/static/layout_edit.js#L489)

cover.js renamed to compose.js to better reflect it's purpose

Note: This is not urgent just offering it as something to help (before I forget)