### PR TITLE
Fix StaleElementReferenceException in some cases.

### DIFF
--- a/src/collective/cover/tests/cover.robot
+++ b/src/collective/cover/tests/cover.robot
@@ -105,7 +105,7 @@ Delete Tile
 Compose Cover
     [Documentation]  Click on Compose tab and wait until the layout has been
     ...              loaded.
-    Click Link  link=Compose
+    Wait Until Keyword Succeeds  5 sec  1 sec  Click Link  link=Compose
     Sleep  1s  Wait for cover compose to load
     Wait Until Page Contains Element  css=div#contentchooser-content-show-button
     Page Should Contain  Add Content


### PR DESCRIPTION
When trying to use the keyword "Compose Cover" in some packages that
use collective.cover as a dependency, the error

    StaleElementReferenceException: Message: Element not found in the cache - perhaps the page has changed since it was looked up

happens in an intermitent manner. Adding

    Wait Until Keyword Succeeds  5 sec  1 sec

avoids this problem.

This solution was already discussed with the community in

http://www.coactivate.org/projects/barcelona-sprint/lists/barcelona-sprint-discussion/archive/2013/02/1360419825199/forum_view