### PR TITLE
Add new permission to restrict code inclussion on the Embed tile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ There's a frood who really knows where his towel is.
 - Create format options for datetime widget (closes `#534`_).
   [rodfersou]
 
+- Add new permission to restrict code inclussion on the Embed tile;
+  now, by default, only Managers and Site Administrators are able to insert code in the tile.
+  The provided upgrade step also fixes the roles assigned to the collective.cover.Setup permission that was broken on the previous release.
+  (closes `#297`_).
+  [hvelarde]
+
 - Add warning to the developer docs that existing custom grid systems have to be upgraded after release 1.0a11 because of internal data structure changes, otherwise your cover columns will be seem to reset to width "1" (closes `#530`_).
   [fredvd]
 
@@ -620,6 +626,7 @@ There's a frood who really knows where his towel is.
 .. _`#281`: https://github.com/collective/collective.cover/issues/281
 .. _`#294`: https://github.com/collective/collective.cover/issues/294
 .. _`#295`: https://github.com/collective/collective.cover/issues/295
+.. _`#297`: https://github.com/collective/collective.cover/issues/297
 .. _`#298`: https://github.com/collective/collective.cover/issues/298
 .. _`#301`: https://github.com/collective/collective.cover/issues/301
 .. _`#303`: https://github.com/collective/collective.cover/issues/303

--- a/src/collective/cover/permissions.zcml
+++ b/src/collective/cover/permissions.zcml
@@ -1,6 +1,11 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
   <permission
+      id="collective.cover.Setup"
+      title="collective.cover: Setup"
+      />
+
+  <permission
       id="collective.cover.CanExportLayout"
       title="collective.cover: Can Export Layout"
       />
@@ -11,10 +16,8 @@
       />
 
   <permission
-      id="collective.cover.Setup"
-      title="collective.cover: Setup">
-    <role name="Manager"/>
-    <role name="Site Administrator"/>
-  </permission>
+      id="collective.cover.EmbedCode"
+      title="collective.cover: Embed Code"
+      />
 
 </configure>

--- a/src/collective/cover/profiles/default/metadata.xml
+++ b/src/collective/cover/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>11</version>
+  <version>12</version>
   <dependencies>
     <dependency>profile-collective.js.galleria:default</dependency>
     <dependency>profile-collective.js.jqueryui:default</dependency>

--- a/src/collective/cover/profiles/default/rolemap.xml
+++ b/src/collective/cover/profiles/default/rolemap.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0"?>
- <rolemap>
-   <permissions>
-     <permission name="collective.cover: Can Export Layout" acquire="False">
-       <role name="Manager"/>
-       <role name="Site Administrator"/>
-     </permission>
-     <permission name="collective.cover: Can Edit Layout" acquire="False">
-       <role name="Manager"/>
-       <role name="Site Administrator"/>
-     </permission>
-   </permissions>
- </rolemap>
+<rolemap>
+  <permissions>
+    <permission name="collective.cover: Setup" acquire="False">
+      <role name="Manager"/>
+      <role name="Site Administrator"/>
+    </permission>
+    <permission name="collective.cover: Can Export Layout" acquire="False">
+      <role name="Manager"/>
+      <role name="Site Administrator"/>
+    </permission>
+    <permission name="collective.cover: Can Edit Layout" acquire="False">
+      <role name="Manager"/>
+      <role name="Site Administrator"/>
+    </permission>
+    <permission name="collective.cover: Embed Code" acquire="False">
+      <role name="Manager"/>
+      <role name="Site Administrator"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/src/collective/cover/tests/test_permissions.py
+++ b/src/collective/cover/tests/test_permissions.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from collective.cover.testing import INTEGRATION_TESTING
+
+import unittest
+
+
+class PermissionsTestCase(unittest.TestCase):
+
+    layer = INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_setup_permission(self):
+        permission = 'collective.cover: Can Export Layout'
+        roles = self.portal.rolesOfPermission(permission)
+        roles = [r['name'] for r in roles if r['selected']]
+        expected = ['Manager', 'Site Administrator']
+        self.assertListEqual(roles, expected)
+
+    def test_can_export_layout_permission(self):
+        permission = 'collective.cover: Can Export Layout'
+        roles = self.portal.rolesOfPermission(permission)
+        roles = [r['name'] for r in roles if r['selected']]
+        expected = ['Manager', 'Site Administrator']
+        self.assertListEqual(roles, expected)
+
+    def test_can_edit_layout_permission(self):
+        permission = 'collective.cover: Can Edit Layout'
+        roles = self.portal.rolesOfPermission(permission)
+        roles = [r['name'] for r in roles if r['selected']]
+        expected = ['Manager', 'Site Administrator']
+        self.assertListEqual(roles, expected)
+
+    def test_embed_code_permission(self):
+        permission = 'collective.cover: Embed Code'
+        roles = self.portal.rolesOfPermission(permission)
+        roles = [r['name'] for r in roles if r['selected']]
+        expected = ['Manager', 'Site Administrator']
+        self.assertListEqual(roles, expected)

--- a/src/collective/cover/tests/test_setup.py
+++ b/src/collective/cover/tests/test_setup.py
@@ -57,13 +57,6 @@ class InstallTestCase(unittest.TestCase):
         except AttributeError:
             self.fail('Reinstall fails when the record was changed')
 
-    def test_can_export_layout_permission(self):
-        permission = 'collective.cover: Can Export Layout'
-        roles = self.portal.rolesOfPermission(permission)
-        roles = [r['name'] for r in roles if r['selected']]
-        expected = ['Manager', 'Site Administrator']
-        self.assertListEqual(roles, expected)
-
 
 class UninstallTestCase(unittest.TestCase):
 

--- a/src/collective/cover/tests/test_upgrades.py
+++ b/src/collective/cover/tests/test_upgrades.py
@@ -400,3 +400,33 @@ class Upgrade10to11TestCase(UpgradeTestCaseBase):
 
         self.assertEqual(settings.layouts, {'test_layout': expected})
         self.assertEqual(cover.cover_layout, expected)
+
+
+class Upgrade11to12TestCase(UpgradeTestCaseBase):
+
+    def setUp(self):
+        UpgradeTestCaseBase.setUp(self, u'11', u'12')
+
+    def test_registrations(self):
+        version = self.setup.getLastVersionForProfile(self.profile_id)[0]
+        self.assertTrue(int(version) >= int(self.to_version))
+        self.assertEqual(self._how_many_upgrades_to_do(), 1)
+
+    def test_update_role_map(self):
+        # address also an issue with Setup permission
+        title = u'Add Embed Code permission'
+        step = self._get_upgrade_step(title)
+        self.assertIsNotNone(step)
+
+        # simulate state on previous version
+        self.portal._collective_cover__Embed_Code_Permission = ()
+        self.portal._collective_cover__Setup_Permission = ()
+
+        # run the upgrade step to validate the update
+        self._do_upgrade_step(step)
+        permissions = ['collective.cover: Setup', 'collective.cover: Embed Code']
+        expected = ['Manager', 'Site Administrator']
+        for p in permissions:
+            roles = self.portal.rolesOfPermission(p)
+            roles = [r['name'] for r in roles if r['selected']]
+            self.assertListEqual(roles, expected)

--- a/src/collective/cover/tiles/embed.py
+++ b/src/collective/cover/tiles/embed.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-
 from collective.cover import _
 from collective.cover.tiles.base import IPersistentCoverTile
 from collective.cover.tiles.base import PersistentCoverTile
+from plone.autoform.directives import write_permission
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope import schema
 from zope.interface import implements
@@ -10,6 +10,7 @@ from zope.interface import implements
 
 class IEmbedTile(IPersistentCoverTile):
 
+    write_permission(embed='collective.cover.EmbedCode')
     embed = schema.Text(
         title=_(u'Embedding code'),
         required=False,

--- a/src/collective/cover/upgrades/configure.zcml
+++ b/src/collective/cover/upgrades/configure.zcml
@@ -1,5 +1,6 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
   <include package=".v11" />
+  <include package=".v12" />
 
 </configure>

--- a/src/collective/cover/upgrades/v12/__init__.py
+++ b/src/collective/cover/upgrades/v12/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from collective.cover.config import PROJECTNAME
+from collective.cover.logger import logger
+
+
+def update_role_map(setup_tool):
+    """Adds new permission to embed code in the Embed tile."""
+    profile = 'profile-{0}:default'.format(PROJECTNAME)
+    setup_tool.runImportStepFromProfile(profile, 'rolemap')
+    logger.info('Role map updated.')

--- a/src/collective/cover/upgrades/v12/configure.zcml
+++ b/src/collective/cover/upgrades/v12/configure.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="collective.cover">
+
+  <genericsetup:upgradeSteps
+      source="11"
+      destination="12"
+      profile="collective.cover:default">
+
+    <genericsetup:upgradeStep
+        title="Add Embed Code permission"
+        description="Adds new permission to embed code in the Embed tile."
+        handler=".update_role_map"
+        />
+
+  </genericsetup:upgradeSteps>
+
+</configure>


### PR DESCRIPTION
Now, by default, only Managers and Site Administrators are able to insert code in the tile.

closes #297