### PR TITLE
Fix caroussel edit compose on IE11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a12 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix textlinessortable widget for IE11 where IE11 mangles multiform POST data. This fixes removing items from the Caroussel compose widget in IE11.
+  [fredvd]
+
 - Create format options for datetime widget (closes `#534`_).
   [rodfersou]
 

--- a/src/collective/cover/tests/test_textlinessortable_widget.py
+++ b/src/collective/cover/tests/test_textlinessortable_widget.py
@@ -151,6 +151,12 @@ class TestTextLinesSortableWidget(unittest.TestCase):
 
         self.assertDictEqual(extracted_value, expected)
 
+        # Test with weird line separators \n\n in IE11 for the uuids
+        self.request.set(name, u'\n\n'.join(uuids))
+
+        extracted_value = widget.extract()
+        self.assertDictEqual(extracted_value, expected)
+
     def test_utf8_custom_data(self):
         obj = self.portal['my-image']
         obj.setDescription('áéíóú')

--- a/src/collective/cover/widgets/textlinessortable.py
+++ b/src/collective/cover/widgets/textlinessortable.py
@@ -136,7 +136,7 @@ class TextLinesSortableWidget(textlines.TextLinesWidget):
         portal_properties = api.portal.get_tool(name='portal_properties')
         use_view_action = portal_properties.site_properties.getProperty(
             'typesUseViewActionInListings', ())
-        values = self.request.get(self.name).split('\r\n')
+        values = self.request.get(self.name).splitlines()
         uuids = [i for i in values if i]
         results = dict()
         for index, uuid in enumerate(uuids):


### PR DESCRIPTION
Fix textlinessortable widget for IE11 where IE11 mangles multiform POST data. This fixes removing items from the Caroussel compose widget in IE11.