### PR TITLE
Add Cache-Control headers to tile configuration and edit overlay views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ There's a frood who really knows where his towel is.
 1.0a12 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Add Cache-Control headers to the @@configure-tile and @@edit-tile views to prevent Internet Explorer from caching the XHR GET requests for these views. What would happen is that you would see the previious (old) field info if you configured or edited a tile, saved and re-opened the same dialog in IE.
+    
 - Fix textlinessortable widget for IE11 where IE11 mangles multiform POST data. This fixes removing items from the Caroussel compose widget in IE11.
   [fredvd]
 

--- a/src/collective/cover/tiles/configuration_view.py
+++ b/src/collective/cover/tiles/configuration_view.py
@@ -239,3 +239,11 @@ class DefaultConfigureView(layout.FormWrapper):
         if self.form_instance is not None:
             if getattr(self.form_instance, 'tileType', None) is None:
                 self.form_instance.tileType = tileType
+
+    def __call__(self):
+        # We add Cache-Control here because IE9-11 cache XHR GET requests. If
+        # you configure a tile, save and reconfigure you get the previouw
+        # request. IE will list the request as 304 not modified, in its F12
+        # tools, but it is never even requested from the server.
+        self.request.response.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        return super(DefaultConfigureView, self).__call__()

--- a/src/collective/cover/tiles/edit.py
+++ b/src/collective/cover/tiles/edit.py
@@ -107,6 +107,14 @@ class CustomTileEdit(DefaultEditView):
     form = CustomEditForm
     index = ViewPageTemplateFile('templates/tileformlayout.pt')
 
+    def __call__(self):
+        # We add Cache-Control here because IE9-11 cache XHR GET requests. If
+        # you edit a tile, save and re-edit you get the previouw request. IE
+        # will list the request as 304 not modified, in its F12 tools, but it
+        # is never even requested from the server.
+        self.request.response.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        return super(CustomTileEdit, self).__call__()
+
 
 class CoverTileEditView(EditTile):
     """


### PR DESCRIPTION
This prevents Internet Explorer from caching the XHR GET requests for these views. What would happen is that you would see the previious (old) field info if you configured or edited a tile, saved and re-opened the same dialog in IE.