### PR TITLE
Use specified scale on tile to fetch scaled image, instead of full sized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a12 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- When fetching image from content object, fetch the tile scale to ensure we get a correct crop from plone.app.imagecropping and don't waste space storing a full sized image.
+  [alecm]
+
 - Add Cache-Control headers to the @@configure-tile and @@edit-tile views to prevent Internet Explorer from caching the XHR GET requests for these views. What would happen is that you would see the previious (old) field info if you configured or edited a tile, saved and re-opened the same dialog in IE.
     
 - Fix textlinessortable widget for IE11 where IE11 mangles multiform POST data. This fixes removing items from the Caroussel compose widget in IE11.

--- a/src/collective/cover/tiles/base.py
+++ b/src/collective/cover/tiles/base.py
@@ -412,10 +412,11 @@ class PersistentCoverTile(tiles.PersistentTile, ESITile):
         :rtype: NamedBlobImage instance or None
         """
         image = None
+        scale = self.scale
         # if has image, store a copy of its data
         if self._has_image_field(obj) and self._field_is_visible('image'):
             scales = obj.restrictedTraverse('@@images')
-            image = scales.scale('image', None)
+            image = scales.scale('image', scale)
 
         if image is not None and image != '':
             if isinstance(image.data, NamedBlobImage):


### PR DESCRIPTION
When cloning an image from a content object, fetch the scale configured on the tile to ensure we get a correct crop from plone.app.imagecropping and don't waste space storing a full sized image that won't be rendered.