### PR TITLE
Shows message if an exception is thrown (fix #581)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a13 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Shows message to user if an exception is thrown in a tile (closes `#581`_).
+  [idgserpro]
+
 - Fix date format in collection tiles (closes `#584`_).
   [tcurvelo]
 
@@ -734,5 +737,6 @@ There's a frood who really knows where his towel is.
 .. _`#534`: https://github.com/collective/collective.cover/issues/534
 .. _`#543`: https://github.com/collective/collective.cover/issues/543
 .. _`#559`: https://github.com/collective/collective.cover/issues/559
+.. _`#581`: https://github.com/collective/collective.cover/issues/581
 .. _`#584`: https://github.com/collective/collective.cover/issues/584
 .. _`PloneFormGen`: https://pypi.python.org/pypi/Products.PloneFormGen

--- a/src/collective/cover/static/js/compose.js
+++ b/src/collective/cover/static/js/compose.js
@@ -38,6 +38,12 @@ function removeObjFromTile() {
         TitleMarkupSetup();
         tile.find('.loading-mask').removeClass('show remove-tile');
         return false;
+      },
+      error: function(XMLHttpRequest, textStatus, errorThrown) {
+        tile.html(textStatus + ': ' + errorThrown);
+        TitleMarkupSetup();
+        tile.find('.loading-mask').removeClass('show remove-tile');
+        return false;
       }
     });
   });
@@ -76,6 +82,11 @@ $(document).ready(function() {
         },
         success: function(info) {
           tile.html(info);
+          TitleMarkupSetup();
+          return false;
+        },
+        error: function(XMLHttpRequest, textStatus, errorThrown) {
+          tile.html(textStatus + ': ' + errorThrown);
           TitleMarkupSetup();
           return false;
         }

--- a/src/collective/cover/static/js/contentchooser.js
+++ b/src/collective/cover/static/js/contentchooser.js
@@ -480,8 +480,18 @@ var coveractions = {
                   }
                   move_callback();
                   return false;
+                },
+                error: function(XMLHttpRequest, textStatus, errorThrown) {
+                  $origin.html(textStatus + ': ' + errorThrown);
+                  $origin.find('.loading-mask').removeClass('show');
+                  return false;
                 }
               });
+              return false;
+            },
+            error: function(XMLHttpRequest, textStatus, errorThrown) {
+              $target.html(textStatus + ': ' + errorThrown);
+              $target.find('.loading-mask').removeClass('show');
               return false;
             }
           });
@@ -499,6 +509,12 @@ var coveractions = {
                 $target.attr('data-content-uuid', draggable_uuid);
                 $target.attr('data-content-type', draggable_type);
               }
+              $target.find('.loading-mask').removeClass('show');
+              TitleMarkupSetup();
+              return false;
+            },
+            error: function(XMLHttpRequest, textStatus, errorThrown) {
+              $target.html(textStatus + ': ' + errorThrown);
               $target.find('.loading-mask').removeClass('show');
               TitleMarkupSetup();
               return false;

--- a/src/collective/cover/tests/TestInternalServerError.py
+++ b/src/collective/cover/tests/TestInternalServerError.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+"""
+
+XXX:
+
+This module for helping in our test is really ugly but we didn't have a better
+option.
+
+The idea of the test is to raise an exception to force the javascript to print
+
+    "Internal Server Error"
+
+on the tile. An earlier simple test was made, that consisted of inserting an
+invalid image (we took a zip file and changed it's extension to jpg) in the
+tile and waiting for "Internal Server Error" string. So far, so good. It
+perfectly worked when using bin/instance to add this image to a tile.
+
+The problem is: different behaviors were happening when using bin/instance for
+this manual test and when using bin/test. An issue was opened in
+
+    https://github.com/collective/collective.cover/issues/586
+
+to try to solve this difference in behavior when using plone.app.testing
+machinery.
+
+Until this issue is not resolved, there's no other way to force an exception in
+a tile other than using a patch like the one below. At least this is a keyword
+in this library and perfectly documented in test_basic_tile.robot.
+
+When issue 586 is solved, this patch can be removed and a new test adding an
+invalid image can be created to test the "Internal Server Error" string.
+
+"""
+
+from collective.cover.tiles.basic import BasicTile
+
+ORIGINAL_POPULATE_WITH_OBJECT = BasicTile.populate_with_object
+
+
+def apply_patch_populate_with_object():
+
+    def patched_populate_with_object(self, obj):
+        raise Exception('Testing Server Error.')
+
+    BasicTile.populate_with_object = patched_populate_with_object
+
+
+def remove_patch_populate_with_object():
+    BasicTile.populate_with_object = ORIGINAL_POPULATE_WITH_OBJECT

--- a/src/collective/cover/tests/test_basic_tile.robot
+++ b/src/collective/cover/tests/test_basic_tile.robot
@@ -2,7 +2,7 @@
 
 Resource  cover.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
-
+Library  ${CURDIR}/TestInternalServerError.py
 Suite Setup  Open Test Browser
 Suite Teardown  Close all browsers
 
@@ -69,6 +69,16 @@ Test Basic Tile
     # move to the default view and check tile persisted
     Click Link  link=View
     Page Should Contain  Test image
+
+    # drag&drop an Image, forcing an error in the server. This error is made
+    # possible using the keyword below from TestInternalServerError.py Library.
+    Apply Patch Populate With Object
+    Compose Cover
+    Open Content Chooser
+    Drag And Drop  css=${image_selector}  css=${tile_selector}
+    Wait Until Page Contains Element  css=div.cover-basic-tile a img
+    Page Should Contain  Internal Server Error
+    Remove Patch Populate With Object
 
     # drag&drop a Link
     Compose Cover


### PR DESCRIPTION
When composing, if an error occurs in a tile and an exception is thrown,
nothing is shown to the user. This commit fixes this behavior, closing

    https://github.com/collective/collective.cover/issues/581