### PR TITLE
Remove 'magic' around plone.app.stagingbehavior dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,6 @@ There's a frood who really knows where his towel is.
 
 - Remove hard dependency on plone.app.stagingbehavior as that package is no longer needed in Plone 5.
   Under Plone < 5.0 you should now explicitly add it to the `eggs` part of your buildout configuration to avoid issues while upgrading.
-  Support for checkout and checkin operations will be automatically configured if ``plone.app.stagingbehavior`` is available.
   [hvelarde]
 
 - Implement drag and drop among tiles (closes `#487`_).

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,6 @@ To enable this package in a buildout-based installation:
     ...
     eggs =
         collective.cover
-        plone.app.stagingbehavior
 
     [versions]
     ...

--- a/src/collective/cover/profiles.zcml
+++ b/src/collective/cover/profiles.zcml
@@ -32,14 +32,6 @@
   <utility factory=".setuphandlers.HiddenProfiles" name="collective.cover" />
   <utility factory=".setuphandlers.HiddenProducts" name="collective.cover" />
 
-  <genericsetup:importStep
-      name="collective.cover"
-      title="collective.cover: setup"
-      description="Import step for configuration that is not handled in XML files."
-      handler="collective.cover.setuphandlers.import_various">
-    <depends name="content" />
-  </genericsetup:importStep>
-
   <genericsetup:upgradeSteps
       source="5"
       destination="6"

--- a/src/collective/cover/setuphandlers.py
+++ b/src/collective/cover/setuphandlers.py
@@ -1,20 +1,7 @@
 # -*- coding: utf-8 -*-
-from collective.cover.config import PROJECTNAME
-from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFPlone import interfaces as Plone
 from Products.CMFQuickInstallerTool import interfaces as QuickInstaller
-from zope.component import queryUtility
 from zope.interface import implements
-
-import logging
-import pkg_resources
-
-try:
-    pkg_resources.get_distribution('plone.app.stagingbehavior')
-except pkg_resources.DistributionNotFound:
-    IStagingSupport = None
-else:
-    from plone.app.stagingbehavior.interfaces import IStagingSupport
 
 
 class HiddenProfiles(object):
@@ -37,26 +24,3 @@ class HiddenProducts(object):
         """Do not show on QuickInstaller's list of installable products."""
         return [
         ]
-
-
-def import_various(context):
-    """Import step for configuration that is not handled in XML files:
-
-    Add staging behavior to content type. This will not be needed
-    under Plone 5 as checkout and checkin operations are directly
-    provided by plone.app.iterate.
-    """
-    if context.readDataFile('collective.cover.marker.txt') is None:
-        return
-
-    if IStagingSupport is not None:
-        fti = queryUtility(IDexterityFTI, name='collective.cover.content')
-        behaviors = list(fti.behaviors)
-
-        if IStagingSupport.__identifier__ in behaviors:
-            return
-
-        behaviors.append(IStagingSupport.__identifier__)
-        fti.behaviors = tuple(behaviors)
-        logger = logging.getLogger(PROJECTNAME)
-        logger.info('Staging behavior for Cover content type was enabled.')

--- a/src/collective/cover/testing.py
+++ b/src/collective/cover/testing.py
@@ -7,9 +7,6 @@ features we want to test:
 plone.app.contenttypes:
     installed under Plone 4.3, if requested; installed under Plone 5
 
-plone.app.stagingbehavior
-    installed under Plone 4 only
-
 plone.app.widgets
     installed under Plone 4.3, if requested
 
@@ -133,9 +130,6 @@ class Fixture(PloneSandboxLayer):
 
     def setUpZope(self, app, configurationContext):
         if PLONE_VERSION < '5.0':
-            import plone.app.stagingbehavior
-            self.loadZCML(package=plone.app.stagingbehavior)
-
             if DEXTERITY_ONLY:
                 import plone.app.contenttypes
                 self.loadZCML(package=plone.app.contenttypes)

--- a/src/collective/cover/tests/test_cover.py
+++ b/src/collective/cover/tests/test_cover.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import Unauthorized
 from collective.cover.config import DEFAULT_GRID_SYSTEM
-from collective.cover.config import PLONE_VERSION
 from collective.cover.controlpanel import ICoverSettings
 from collective.cover.interfaces import ICover
 from collective.cover.testing import INTEGRATION_TESTING
@@ -62,12 +61,6 @@ class CoverIntegrationTestCase(unittest.TestCase):
     def test_is_referenceable(self):
         self.assertTrue(IReferenceable.providedBy(self.cover))
         self.assertTrue(IAttributeUUID.providedBy(self.cover))
-
-    @unittest.skipIf(
-        PLONE_VERSION < '5.0', 'plone.app.stagingbehavior not needed')
-    def test_staging_behavior(self):
-        from plone.app.stagingbehavior.interfaces import IStagingSupport
-        self.assertTrue(IStagingSupport.providedBy(self.cover))
 
     def test_cover_selectable_as_folder_default_view(self):
         self.folder.setDefaultPage('c1')

--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -1,7 +1,6 @@
 [buildout]
 test-eggs =
     Pillow
-    plone.app.stagingbehavior
 
 [versions]
 collective.js.bootstrap = 2.3.1.1

--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -1,7 +1,6 @@
 [buildout]
 test-eggs =
     plone.app.contenttypes
-    plone.app.stagingbehavior
     plone.app.widgets
 
 [versions]


### PR DESCRIPTION
We simply should not depend on it in any way; that's most likely the work of a policy package.