### PR TITLE
Remove Grok Dependency for Cover View.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ There's a frood who really knows where his towel is.
   a few bugs related with API incompatibilities among Archetypes and Dexterity were fixed.
   [hvelarde]
 
-- Remove Grok dependency for vocabularies.
+- Remove Grok dependency from views and vocabularies.
   [l34marr]
 
 - You can now use a collection to populate a carousel tile;

--- a/src/collective/cover/browser/configure.zcml
+++ b/src/collective/cover/browser/configure.zcml
@@ -7,10 +7,113 @@
     >
 
   <browser:page
+      name="view"
+      for="..interfaces.ICover"
+      permission="zope2.View"
+      class=".cover.View"
+      template="templates/view.pt"
+      />
+
+  <browser:page
+      name="standard"
+      for="..interfaces.ICover"
+      permission="zope2.View"
+      class=".cover.Standard"
+      template="templates/standard.pt"
+      />
+
+  <browser:page
+      name="addctwidget"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.AddCTWidget"
+      />
+
+  <browser:page
+      name="addtilewidget"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.AddTileWidget"
+      />
+
+  <browser:page
+      name="setwidgetmap"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.SetWidgetMap"
+      />
+
+  <browser:page
+      name="updatewidget"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.UpdateWidget"
+      />
+
+  <browser:page
+      name="removetilewidget"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.RemoveTileWidget"
+      template="templates/removetilewidget.pt"
+      />
+
+  <browser:page
+      name="compose"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.Compose"
+      template="templates/compose.pt"
+      />
+
+  <browser:page
+      name="layoutedit"
+      for="..interfaces.ICover"
+      permission="collective.cover.CanEditLayout"
+      class=".cover.LayoutEdit"
+      template="templates/layoutedit.pt"
+      />
+
+  <browser:page
+      name="updatetilecontent"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.UpdateTileContent"
+      />
+
+  <browser:page
       name="movetilecontent"
       for="..interfaces.ICover"
       permission="cmf.ModifyPortalContent"
       class=".cover.MoveTileContent"
+      />
+
+  <browser:page
+      name="updatetile"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.UpdateTile"
+      />
+
+  <browser:page
+      name="updatelisttilecontent"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.UpdateListTileContent"
+      />
+
+  <browser:page
+      name="removeitemfromlisttile"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.RemoveItemFromListTile"
+      />
+
+  <browser:page
+      name="deletetile"
+      for="..interfaces.ICover"
+      permission="cmf.ModifyPortalContent"
+      class=".cover.DeleteTile"
       />
 
 </configure>

--- a/src/collective/cover/browser/cover.py
+++ b/src/collective/cover/browser/cover.py
@@ -2,22 +2,22 @@
 from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from collective.cover.controlpanel import ICoverSettings
-from collective.cover.interfaces import ICover
 from collective.cover.interfaces import IGridSystem
 from collective.cover.tiles.list import IListTile
 from collective.cover.vocabularies import TileStylesVocabulary
-from five import grok
 from plone import api
 from plone.app.blocks.interfaces import IBlocksTransformEnabled
 from plone.app.uuid.utils import uuidToObject
 from plone.dexterity.events import EditBegunEvent
 from plone.dexterity.utils import createContentInContainer
+from plone.dexterity.browser.view import DefaultView
 from plone.registry.interfaces import IRegistry
 from plone.tiles.interfaces import ITileDataManager
 from plone.uuid.interfaces import IUUID
 from plone.uuid.interfaces import IUUIDGenerator
 from Products.Five.browser import BrowserView
 from zExceptions import BadRequest
+from zope.interface import implements
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.event import notify
@@ -26,26 +26,15 @@ from zope.lifecycleevent import ObjectModifiedEvent
 import json
 
 
-grok.templatedir('templates')
+class View(BrowserView):
+    implements(IBlocksTransformEnabled)
 
 
-class View(grok.View):
-    grok.context(ICover)
-    grok.implements(IBlocksTransformEnabled)
-    grok.require('zope2.View')
-    grok.name('view')
+class Standard(BrowserView):
+    implements(IBlocksTransformEnabled)
 
 
-class Standard(grok.View):
-    grok.context(ICover)
-    grok.implements(IBlocksTransformEnabled)
-    grok.require('zope2.View')
-    grok.name('standard')
-
-
-class AddCTWidget(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class AddCTWidget(DefaultView):
 
     def render(self):
         widget_type = self.request.get('widget_type')
@@ -63,9 +52,7 @@ class AddCTWidget(grok.View):
                            'widget_url': widget_url})
 
 
-class AddTileWidget(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class AddTileWidget(DefaultView):
 
     def render(self):
         uuid = getUtility(IUUIDGenerator)
@@ -92,9 +79,7 @@ class AddTileWidget(grok.View):
                            'widget_url': widget_url})
 
 
-class SetWidgetMap(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class SetWidgetMap(DefaultView):
 
     def render(self):
         widget_map = self.request.get('widget_map')
@@ -103,9 +88,7 @@ class SetWidgetMap(grok.View):
         return json.dumps('success')
 
 
-class UpdateWidget(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class UpdateWidget(DefaultView):
 
     def render(self):
         widget_id = self.request.get('wid')
@@ -115,11 +98,8 @@ class UpdateWidget(grok.View):
             return 'Widget does not exist'
 
 
-class RemoveTileWidget(grok.View):
+class RemoveTileWidget(DefaultView):
     # XXX: This should be part of the plone.app.tiles package or similar
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
-    grok.name('removetilewidget')
 
     def __call__(self):
         template = self.template
@@ -142,10 +122,8 @@ class RemoveTileWidget(grok.View):
 
 # TODO: implement EditCancelledEvent and EditFinishedEvent
 # XXX: we need to leave the view after saving or cancelling editing
-class Compose(grok.View):
-    grok.context(ICover)
-    grok.implements(IBlocksTransformEnabled)
-    grok.require('cmf.ModifyPortalContent')
+class Compose(BrowserView):
+    implements(IBlocksTransformEnabled)
 
     def update(self):
         self.context = aq_inner(self.context)
@@ -155,9 +133,7 @@ class Compose(grok.View):
 
 # TODO: implement EditCancelledEvent and EditFinishedEvent
 # XXX: we need to leave the view after saving or cancelling editing
-class LayoutEdit(grok.View):
-    grok.context(ICover)
-    grok.require('collective.cover.CanEditLayout')
+class LayoutEdit(DefaultView):
 
     def update(self):
         self.context = aq_inner(self.context)
@@ -198,12 +174,9 @@ class LayoutEdit(grok.View):
         return json.dumps({'ncolumns': grid.ncolumns})
 
 
-class UpdateTileContent(grok.View):
+class UpdateTileContent(DefaultView):
 
     """Helper browser view to update the content of a tile."""
-
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
 
     def render(self):
         """Render a tile after populating it with an object."""
@@ -279,9 +252,7 @@ class MoveTileContent(BrowserView):
         return target_tile()
 
 
-class UpdateTile(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class UpdateTile(DefaultView):
 
     def render(self):
         tile_type = self.request.form.get('tile-type')
@@ -293,9 +264,7 @@ class UpdateTile(grok.View):
         return tile_instance()
 
 
-class UpdateListTileContent(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class UpdateListTileContent(DefaultView):
 
     def render(self):
         tile_type = self.request.form.get('tile-type')
@@ -319,12 +288,9 @@ class UpdateListTileContent(grok.View):
         return html
 
 
-class RemoveItemFromListTile(grok.View):
+class RemoveItemFromListTile(DefaultView):
 
     """Helper browser view to remove an object from a list tile."""
-
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
 
     def render(self):
         """Render a tile after removing an object from it."""
@@ -340,9 +306,7 @@ class RemoveItemFromListTile(grok.View):
             raise BadRequest('Invalid parameters')
 
 
-class DeleteTile(grok.View):
-    grok.context(ICover)
-    grok.require('cmf.ModifyPortalContent')
+class DeleteTile(DefaultView):
 
     def render(self):
         tile_type = self.request.form.get('tile-type')


### PR DESCRIPTION
Another small step toward removing Grok dependency.

For the record: By first try, I assume all classes in browser/cover.py are equally Browser Views. Then I run into an error:
`LocationError: (<Products.Five.metaclass.SimpleViewClass from ...)`
that leads me to https://github.com/collective/collective.nitf/issues/80
So I try some DefaultView instead of BrowserView. It seems working, but I might need advice or insight.