### PR TITLE
Manually declare funcsigs as a dependency

### DIFF
--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -2,6 +2,8 @@
 test-eggs =
     Pillow
     plone.app.referenceablebehavior
+# https://github.com/testing-cabal/mock/issues/261
+    funcsigs
 
 [versions]
 collective.js.bootstrap = 2.3.1.1


### PR DESCRIPTION
This is needed by mock.

See: https://github.com/testing-cabal/mock/issues/261