### PR TITLE
Fix backwards compatibility for BaseGrid

### DIFF
--- a/src/collective/cover/layout.py
+++ b/src/collective/cover/layout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # TODO: this module must be removed in 1.4 release
-from collective.cover.grid import BaseGrid  # noqa
+from collective.cover.grids import BaseGrid  # noqa
 from zope import deprecation
 
 


### PR DESCRIPTION
If you want to import BaseGrid, get it from the right location.