### PR TITLE
Avoid exceptions while using the content chooser in Plone 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.3b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Avoid exceptions while using the content chooser in Plone 5.
+  [hvelarde]
+
 - Add helper function to get the human representation of a mime-type on Dexterity-based content types.
   This fixed an ``AttributeError`` that was causing an exception on Plone 5.
   [hvelarde]

--- a/src/collective/cover/browser/templates/search_list.pt
+++ b/src/collective/cover/browser/templates/search_list.pt
@@ -10,7 +10,7 @@
                             children python: [];
                             item_url node/getURL;
                             item_token  python:view.getTermByBrain(node['item']).token;
-                            item_icon node/item_icon;
+                            item_icon node/item_icon|nothing;
                             content_type node/portal_type;
                             content_path python:node['path'][len(portal_path):]"
                 tal:attributes="data-content-type type;


### PR DESCRIPTION
fixes #639 