### PR TITLE
Remove plone app robotframework

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,7 +2,6 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.github.com/plone/plone.app.robotframework/master/versions.cfg
     versions-4.3.x.cfg
 
 package-name = collective.cover

--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -4,6 +4,18 @@ test-eggs =
     plone.app.referenceablebehavior
 # https://github.com/testing-cabal/mock/issues/261
     funcsigs
+    
+
+extends = 
+# When trying to remove plone.app.robotframework pins (check
+# https://github.com/collective/collective.cover/issues/672)
+# We realized that http://dist.plone.org/release/4.2-latest/versions.cfg
+# doesn't pin any of this infrastructure, thus giving
+# "WebDriverException: Message: 'geckodriver' executable needs to be in PATH."
+# error. So we can remove this pin from 4.3 onwards since
+# http://dist.plone.org/release/4.3-latest/versions.cfg pins robots
+# infrastructure but 4.2 still needs it.
+    https://raw.github.com/plone/plone.app.robotframework/master/versions.cfg
 
 [versions]
 collective.js.bootstrap = 2.3.1.1


### PR DESCRIPTION
we realized the pins we made for plone.app.robotframework are only useful for Plone 4.2:

http://dist.plone.org/release/4.2-latest/versions.cfg 

doesn't pin any of robots infrastructure, so it seems that, at least for 4.2, we still need to use

https://raw.github.com/plone/plone.app.robotframework/master/versions.cfg

closes  #672