### PR TITLE
Fixed adding a 'more' link in list tiles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     permissions: public-read
     paths:
     - $(find parts/test -type f | tr "\n" ":")
+  firefox: latest-esr
 env:
   matrix:
     - PLONE_VERSION=4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,11 @@ after_success:
 - bin/createcoverage -t "--layer=!Robot"
 - pip install coveralls
 - coveralls
+after_script:
+# Firefox complains: GConf-WARNING **: Got Disconnected from DBus.
+# And then it keeps hanging, causing a failed job after 30-50 minutes.
+# So we just kill Firefox.
+- pkill -9 firefox
 notifications:
   irc:
     on_success: change

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ There's a frood who really knows where his towel is.
 1.3b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fixed adding a 'more' link in list tiles.
+  Previously you could select an item to use as 'more' link,
+  but it did not stick.  [maurits]
+
 - The ``replace_with_objects`` method was removed from the list tile;
   use ``replace_with_uuids`` instead.
   [hvelarde]

--- a/src/collective/cover/tests/test_list_tile.robot
+++ b/src/collective/cover/tests/test_list_tile.robot
@@ -95,7 +95,7 @@ Test List Tile
     Drag And Drop  css=${first_item}  css=${last_item}
     Sleep  1s  Wait for reordering to occur
 
-    # ensure that the reodering is reflected in the DOM
+    # ensure that the reordering is reflected in the DOM
     ${first_item_title} =  Get Text  css=${first_item} h2
     ${last_item_title} =  Get Text  css=${last_item} h2
     Should Be Equal  ${first_item_title}  My file
@@ -108,6 +108,21 @@ Test List Tile
     # ensure that the reodering is reflected in the DOM
     ${first_item_title} =  Get Text  css=${first_item} h2
     Should Be Equal  ${first_item_title}  My document
+
+    # Set options on the Edit screen of the tile.
+    # Set a title and set the 'Mandelbrot set' collection as 'more' link.
+    Compose Cover
+    Click Link  css=.edit-tile-link
+    Input Text  id=collective-cover-list-tile_title  Custom List Tile Title
+    Click Button  css=.more_link_search_button
+    Click Link  css=.results .item-list li a.contenttype-collection
+    Input Text  id=collective-cover-list-more_link_text  Custom More Link Text
+    Click Button  Save
+    # Wait until the overlay is closed, otherwise the View link is not clickable.
+    Wait Until Element Is Not Visible  css=#exposeMask
+    Click Link  link=View
+    Page Should Contain  Custom List Tile Title
+    Page Should Contain  Custom More Link Text
 
     # delete the tile
     Open Layout Tab

--- a/src/collective/cover/tiles/edit_widgets/more_link.pt
+++ b/src/collective/cover/tiles/edit_widgets/more_link.pt
@@ -16,7 +16,7 @@
         <div class="search">
             <input class="search" />
             <button tal:attributes="data-url view/form/context/absolute_url"
-                    class="search" type="button">Search</button>
+                    class="search more_link_search_button" type="button">Search</button>
         </div>
         <ul class="results"></ul>
         <script>
@@ -47,7 +47,7 @@
          });
 
          $field.find('.results').on('click', 'li', function() {
-             $field.find('.uuid').val( $(this).attr ('uuid') );
+             $field.find('.uuid').val( $(this).attr ('data-content-uuid') );
              $field.find('.title').text( $(this).find ('a').text () );
              toggle_unlink();
          });


### PR DESCRIPTION
Previously you could select an item to use as 'more' link, but it did not stick.
I checked previous versions: this worked in 1.0a12, but failed since 1.1b1.

I have expanded the robot test for the list tile.
For clarity let me give two screen shots made during this test.

First a screen shot of the filled-in list tile edit form:

![screen shot 2016-11-11 at 18 42 53](https://cloud.githubusercontent.com/assets/210587/20224671/e5411094-a83f-11e6-881f-4fa765fd5569.png)

And then the resulting view, annotated for clarity:

![screen shot 2016-11-11 at 18 43 14 annotated](https://cloud.githubusercontent.com/assets/210587/20224796/9d827918-a840-11e6-8d72-7a8f60e1e20f.png)

