### PR TITLE
Don't use firefox latest-esr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     permissions: public-read
     paths:
     - $(find parts/test -type f | tr "\n" ":")
+  firefox: 45.6.0
 env:
   matrix:
     - PLONE_VERSION=4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     permissions: public-read
     paths:
     - $(find parts/test -type f | tr "\n" ":")
-  firefox: latest-esr
 env:
   matrix:
     - PLONE_VERSION=4.2

--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -4,9 +4,9 @@ test-eggs =
     plone.app.referenceablebehavior
 # https://github.com/testing-cabal/mock/issues/261
     funcsigs
-    
 
-extends = 
+
+extends =
 # When trying to remove plone.app.robotframework pins (check
 # https://github.com/collective/collective.cover/issues/672)
 # We realized that http://dist.plone.org/release/4.2-latest/versions.cfg
@@ -20,6 +20,8 @@ extends =
 [versions]
 collective.js.bootstrap = 2.3.1.1
 collective.js.jqueryui = 1.8.16.9
+# XXX: https://github.com/plone/plone.api/issues/364
+plone.api = 1.6
 plone.app.blocks = 3.1.0
 plone.app.drafts = 1.0
 plone.app.jquery = 1.7.2

--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -12,3 +12,5 @@ plone.tiles = 1.8.0
 
 # for testing compatibility with newer versions of jQuery
 plone.app.jquery = 1.7.2
+
+z3c.form = 3.2.9

--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -1,13 +1,4 @@
 [buildout]
-extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
-    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
-    http://dist.plone.org/release/4.3.11/versions.cfg
-
-find-links =
-    http://dist.plone.org/release/4.3.11/
-    http://dist.plone.org/thirdparty/
-
 test-eggs =
     plone.app.contenttypes
     plone.app.referenceablebehavior

--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -1,4 +1,13 @@
 [buildout]
+extends =
+    https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
+    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+    http://dist.plone.org/release/4.3.11/versions.cfg
+
+find-links =
+    http://dist.plone.org/release/4.3.11/
+    http://dist.plone.org/thirdparty/
+
 test-eggs =
     plone.app.contenttypes
     plone.app.referenceablebehavior
@@ -12,5 +21,3 @@ plone.tiles = 1.8.0
 
 # for testing compatibility with newer versions of jQuery
 plone.app.jquery = 1.7.2
-
-z3c.form = 3.2.9

--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -5,6 +5,8 @@ test-eggs =
 
 [versions]
 collective.js.bootstrap = 2.3.1.1
+# XXX: https://github.com/plone/plone.api/issues/364
+plone.api = 1.6
 plone.app.blocks = 3.1.0
 plone.app.drafts = 1.0
 plone.app.tiles = 1.1.0


### PR DESCRIPTION
The latest versions of firefox aren't compatible with robot tests in Plone 4.3.

Fix build: https://travis-ci.org/collective/collective.cover/jobs/213520459