### PR TITLE
Remove Pillow from egg-test in Plone 4.2

### DIFF
--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -1,6 +1,5 @@
 [buildout]
 test-eggs =
-    Pillow
     plone.app.referenceablebehavior
 # https://github.com/testing-cabal/mock/issues/261
     funcsigs


### PR DESCRIPTION
Pillow was added in buildout.plonetest in Plone 4.2. See:

https://github.com/collective/buildout.plonetest/commit/9c2d800eab02b1ea3032218c8ade061d47d02be7