### PR TITLE
Use latest versions of all Deco related packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ There's a frood who really knows where his towel is.
 1.4b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+.. Warning::
+    If you are upgrading plone.app.tiles note that latests versions of this package no longer depend on plone.app.drafts.
+    You should explicitly add plone.app.drafts to the `eggs` part of your buildout configuration to avoid issues.
+    You can safely unistall plone.app.drafts after that, if you are not using it.
+
+- Update recommended versions of Blocks dependencies to keep in sync with curren Mosaic development.
+  [hvelarde]
+
 - Fix order of uuids of sorted function in ListTile's 'results' method.
   [idgserpro]
 

--- a/README.rst
+++ b/README.rst
@@ -116,10 +116,9 @@ Edit your buildout.cfg and add add the following to it:
     [versions]
     ...
     collective.js.bootstrap = 2.3.1.1
-    plone.app.blocks = 3.1.0
-    plone.app.drafts = 1.0
-    plone.app.tiles = 1.1.0
-    plone.tiles = 1.8.0
+    plone.app.blocks = 4.0.6
+    plone.app.tiles = 3.0.3
+    plone.tiles = 2.0.0b2
 
 If you are using Plone 4.2.x you need to add the following also:
 
@@ -127,6 +126,7 @@ If you are using Plone 4.2.x you need to add the following also:
 
     [versions]
     collective.js.jqueryui = 1.8.16.9
+    plone.app.blocks = 3.1.0
     plone.app.jquery = 1.7.2
     plone.app.jquerytools = 1.5.7
     plone.app.z3cform = 0.6.3

--- a/versions-4.2.x.cfg
+++ b/versions-4.2.x.cfg
@@ -19,13 +19,12 @@ extends =
 collective.js.bootstrap = 2.3.1.1
 collective.js.jqueryui = 1.8.16.9
 plone.app.blocks = 3.1.0
-plone.app.drafts = 1.0
 plone.app.jquery = 1.7.2
 plone.app.jquerytools = 1.5.7
-plone.app.tiles = 1.1.0
+plone.app.tiles = 3.0.3
 plone.app.z3cform = 0.6.3
 plone.directives.form = 1.1
-plone.tiles = 1.8.0
+plone.tiles = 2.0.0b2
 
 # for testing
 funcsigs = 0.4

--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -15,10 +15,9 @@ test-eggs =
 
 [versions]
 collective.js.bootstrap = 2.3.1.1
-plone.app.blocks = 3.1.0
-plone.app.drafts = 1.0
-plone.app.tiles = 1.1.0
-plone.tiles = 1.8.0
+plone.app.blocks = 4.0.6
+plone.app.tiles = 3.0.3
+plone.tiles = 2.0.0b2
 
 # for testing compatibility with newer versions of jQuery
 plone.app.jquery = 1.7.2

--- a/versions-5.0.x.cfg
+++ b/versions-5.0.x.cfg
@@ -1,5 +1,1 @@
 [versions]
-collective.js.bootstrap = 2.3.1.1
-plone.app.blocks = 3.1.0
-plone.app.tiles = 1.1.0
-plone.tiles = 1.8.0

--- a/versions-5.1.x.cfg
+++ b/versions-5.1.x.cfg
@@ -1,2 +1,1 @@
 [versions]
-collective.js.bootstrap = 2.3.1.1


### PR DESCRIPTION
we need to keep Deco related packages up to date to avoid surprises.