### PR TITLE
Using sudo: required in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python: 2.7
-sudo: false
+sudo: required
 cache:
   directories:
   - eggs


### PR DESCRIPTION
With that, we have more memory on the Travis infrastructure.  See:

https://docs.travis-ci.com/user/ci-environment/

Maybe that will decrease the Mandelbugs.

Fix #703