### PR TITLE
Do not declare the Cover class as an implementer of IDAVAware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ There's a frood who really knows where his towel is.
 1.4b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Do not declare the ``Cover`` class as an implementer of ``IDAVAware``;
+  This makes absolutely no sense and is causing an error when doing a GenericSetup export (fixes `#396`_).
 
 
 1.4b1 (2016-12-14)
@@ -157,6 +158,7 @@ There's a frood who really knows where his towel is.
 Previous entries can be found in the HISTORY.rst file.
 
 
+.. _`#396`: https://github.com/collective/collective.cover/issues/396
 .. _`#414`: https://github.com/collective/collective.cover/issues/414
 .. _`#487`: https://github.com/collective/collective.cover/issues/487
 .. _`#510`: https://github.com/collective/collective.cover/issues/510

--- a/src/collective/cover/content.py
+++ b/src/collective/cover/content.py
@@ -12,9 +12,7 @@ from plone.dexterity.content import Item
 from plone.indexer import indexer
 from plone.tiles.interfaces import ITileDataManager
 from Products.CMFPlone.utils import safe_unicode
-from Products.GenericSetup.interfaces import IDAVAware
 from zope.component import queryAdapter
-from zope.interface import implementer
 
 import json
 import logging
@@ -23,12 +21,7 @@ import logging
 logger = logging.getLogger(PROJECTNAME)
 
 
-# XXX: Provide this so Cover items can be imported using the import
-#      content from GS, until a proper solution is found.
-#      ref: http://thread.gmane.org/gmane.comp.web.zope.plone.devel/31799
-@implementer(IDAVAware)
 class Cover(Item):
-
     """A composable page."""
 
     @property


### PR DESCRIPTION
This makes absolutely no sense and is causing an error when doing a GenericSetup export.

fixes #396