### PR TITLE
Fix install/uninistall bug when installed alongside plone.app.standardtiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.4b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Do not assume all tile types have schemas.
+  [alecm]
+
 - Do not declare the ``Cover`` class as an implementer of ``IDAVAware``;
   This makes absolutely no sense and is causing an error when doing a GenericSetup export (fixes `#396`_).
 

--- a/src/collective/cover/vocabularies.py
+++ b/src/collective/cover/vocabularies.py
@@ -64,7 +64,7 @@ class EnabledTilesVocabulary(object):
             return False
 
         tile_type = queryUtility(ITileType, name)
-        if tile_type:
+        if tile_type and tile_type.schema:
             return issubclass(tile_type.schema, IPersistentCoverTile)
 
     def __call__(self, context):


### PR DESCRIPTION
Running the install/uninstall profiles for collective.cover results in an exception when Mosaic and plone.app.standardtiles are installed:

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module Products.GenericSetup.tool, line 579, in manage_importAllSteps
    Module Products.GenericSetup.tool, line 388, in runAllImportStepsFromProfile
    - __traceback_info__: profile-collective.cover:uninstall
    Module Products.GenericSetup.tool, line 1433, in _runImportStepsFromContext
    Module Products.GenericSetup.tool, line 1245, in _doRunImportStep
    - __traceback_info__: plone.app.registry
    Module plone.app.registry.exportimport.handler, line 70, in importRegistry
    Module plone.app.registry.exportimport.handler, line 118, in importDocument
    Module plone.app.registry.exportimport.handler, line 385, in importRecords
    - __traceback_info__: records name: collective.cover.controlpanel.ICoverSettings
    Module plone.registry.registry, line 121, in registerInterface
    Module zope.schema._field, line 522, in bind
    Module plone.registry.field, line 292, in bind
    Module Zope2.App.schema, line 33, in get
    Module collective.cover.vocabularies, line 74, in __call__
    Module collective.cover.vocabularies, line 68, in _enabled
    TypeError: issubclass() arg 1 must be a class

This patch leaves out tiles that have a schema of None, avoiding this error.