### PR TITLE
Fix order of uuids of sorted function in ListTile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.4b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix order of uuids of sorted function in ListTile's 'results' method.
+  [idgserpro]
+
 - Review content chooser events to happen just at compose tab (fixes `#710`_).
   [rodfersou]
 

--- a/src/collective/cover/tests/test_list_tile.py
+++ b/src/collective/cover/tests/test_list_tile.py
@@ -171,6 +171,27 @@ class ListTileTestCase(TestTileMixin, unittest.TestCase):
         for i in range(2, 7):
             self.assertIn(folder[str(i)], results)
 
+    def test_results_ordering_uuids_dict(self):
+        # set standard workflow for News Items
+        wt = self.portal['portal_workflow']
+        wt.setChainForPortalTypes(['News Item'], 'simple_publication_workflow')
+        # create some testing content and add it to the tile
+        with api.env.adopt_roles(['Manager']):
+            folder = api.content.create(self.portal, 'Folder', id='test')
+
+        # Test more than 10 items: this situation can happen if you're inheriting
+        # from the TileList.
+        self.tile.limit = 16
+        obj_uuids = []
+        original_order = []
+        for i in range(1, self.tile.limit):
+            obj = api.content.create(folder, 'News Item', id=str(i))
+            obj_uuids.append(obj.UID())
+            original_order.append(int(i))
+            self.tile.populate_with_object(obj)
+        new_order = [int(i.id) for i in self.tile.results()]
+        self.assertEqual(new_order, original_order)
+
     def test_show_start_date_on_events(self):
         event = self.portal['my-event']
         self.tile.populate_with_object(event)

--- a/src/collective/cover/tiles/list.py
+++ b/src/collective/cover/tiles/list.py
@@ -116,7 +116,7 @@ class ListTile(PersistentCoverTile):
         results = list()
         if uuids:
             ordered_uuids = [(k, v) for k, v in uuids.items()]
-            ordered_uuids.sort(key=lambda x: x[1]['order'])
+            ordered_uuids.sort(key=lambda x: int(x[1]['order']))
 
             for uuid in [i[0] for i in ordered_uuids]:
                 obj = uuidToObject(uuid)


### PR DESCRIPTION
Method 'results'.

'order' in tile data is a string, so using sorted function takes into
account string sorting and not int sorting, giving a wrong order when you
have more than 9 items (because you start having 11, 12, 13 and so on as
a string and mangles the sorting).