### PR TITLE
heroku.cfg now extends versions-4.3.x.cfg.

### DIFF
--- a/heroku.cfg
+++ b/heroku.cfg
@@ -1,5 +1,7 @@
 [buildout]
-extends = http://dist.plone.org/release/4.3-latest/versions.cfg
+extends =
+    http://dist.plone.org/release/4.3-latest/versions.cfg
+    versions-4.3.x.cfg
 unzip = true
 newest = false
 versions = versions
@@ -10,11 +12,6 @@ find-links += http://effbot.org/downloads/
 parts =
     instance
     demosite
-
-[versions]
-collective.js.bootstrap = 2.3.1.1
-plone.app.blocks = 2.2.1
-plone.app.tiles = 1.0.2
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
It was already extending

http://dist.plone.org/release/4.3-latest/versions.cfg

So to avoid duplication of a [versions] section for collective.cover's
dependencies, we now extends versions-4.3.x.cfg as well.