### PR TITLE
Fix *UIDsProvider adapters deprecation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ There's a frood who really knows where his towel is.
 1.5b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix adapters ``ICoverUIDsProvider``, ``CollectionUIDsProvider``,
+``FolderUIDsProvider`` and ``GenericUIDsProvider`` that were incorrectly removed
+  in 1.5b1. These classes will still be removed in collective.cover 1.7.
+  [idgserpro]
+
 - Use absolute url for root in content chooser tree.
   This fixes `issue #733 <https://github.com/collective/collective.cover/issues/733>`_.
   [maurits]

--- a/src/collective/cover/interfaces.py
+++ b/src/collective/cover/interfaces.py
@@ -35,6 +35,13 @@ class ICoverUIDsProvider(Interface):
     """GenericUIDsProvider interface will be removed in collective.cover v1.7."""
     warnings.warn(__doc__, DeprecationWarning)
 
+    def getUIDs(self):
+        """Get UUIDs associated with the object.
+            could be the UUID of the object or a
+            list of related UUIDs.
+        @return: iterable of UUIDs
+        """
+
 
 class ITileEditForm(Interface):
     """Custom EditForm interface for a tile.

--- a/src/collective/cover/tiles/configure.zcml
+++ b/src/collective/cover/tiles/configure.zcml
@@ -85,6 +85,36 @@
       permission="zope.Public"
       />
 
+  <!--BEGIN DEPRECATED ADAPTERS. They will be removed on collective.cover 1.7.-->
+  <adapter
+      for="Products.ATContentTypes.interface.IATFolder"
+      provides="..interfaces.ICoverUIDsProvider"
+      factory=".list.FolderUIDsProvider"
+      />
+
+  <!-- Archetypes-based collection -->
+  <adapter
+      zcml:condition="installed plone.app.collection"
+      for="plone.app.collection.interfaces.ICollection"
+      provides="..interfaces.ICoverUIDsProvider"
+      factory=".list.CollectionUIDsProvider"
+      />
+
+  <!-- Dexterity-based collection -->
+  <adapter
+      zcml:condition="installed plone.app.contenttypes"
+      for="plone.app.contenttypes.interfaces.ICollection"
+      provides="..interfaces.ICoverUIDsProvider"
+      factory=".list.CollectionUIDsProvider"
+      />
+
+  <adapter
+      for="*"
+      provides="..interfaces.ICoverUIDsProvider"
+      factory=".list.GenericUIDsProvider"
+      />
+  <!--END DEPRECATED ADAPTERS. They will be removed on collective.cover 1.7.-->
+
   <adapter
       factory=".base.PersistentCoverTilePurgePaths"
       name="collective.cover.tiles"

--- a/src/collective/cover/tiles/list.py
+++ b/src/collective/cover/tiles/list.py
@@ -2,6 +2,7 @@
 from AccessControl import Unauthorized
 from collective.cover import _
 from collective.cover.config import PROJECTNAME
+from collective.cover.interfaces import ICoverUIDsProvider
 from collective.cover.interfaces import ITileEditForm
 from collective.cover.tiles.base import IPersistentCoverTile
 from collective.cover.tiles.base import PersistentCoverTile
@@ -375,34 +376,40 @@ class ListTile(PersistentCoverTile):
         return self._get_title_tag(item)
 
 
+@implementer(ICoverUIDsProvider)
 class CollectionUIDsProvider(object):
     """CollectionUIDsProvider adapter will be removed in collective.cover v1.7."""
     warnings.warn(__doc__, DeprecationWarning)
 
     def __init__(self, context):
-        pass
+        self.context = context
 
     def getUIDs(self):
-        pass
+        """Return a list of UUIDs of collection objects."""
+        return [i.UID for i in self.context.queryCatalog()]
 
 
+@implementer(ICoverUIDsProvider)
 class FolderUIDsProvider(object):
     """FolderUIDsProvider adapter will be removed in collective.cover v1.7."""
     warnings.warn(__doc__, DeprecationWarning)
 
     def __init__(self, context):
-        pass
+        self.context = context
 
     def getUIDs(self):
-        pass
+        """Return a list of UUIDs of collection objects."""
+        return [i.UID for i in self.context.getFolderContents()]
 
 
+@implementer(ICoverUIDsProvider)
 class GenericUIDsProvider(object):
     """GenericUIDsProvider adapter will be removed in collective.cover v1.7."""
     warnings.warn(__doc__, DeprecationWarning)
 
     def __init__(self, context):
-        pass
+        self.context = context
 
     def getUIDs(self):
-        pass
+        """Return a list of UUIDs of collection objects."""
+        return [IUUID(self.context)]


### PR DESCRIPTION
Fix adapters ICoverUIDsProvider, CollectionUIDsProvider, FolderUIDsProvider
and GenericUIDsProvider that were incorrectly removed in 1.5b1. These classes
will still be removed in collective.cover 1.7.