### PR TITLE
use pat-autotoc instead of old formTabbing refs #718

### DIFF
--- a/src/collective/cover/browser/templates/content_contentchooser.pt
+++ b/src/collective/cover/browser/templates/content_contentchooser.pt
@@ -7,17 +7,14 @@
       tal:omit-tag="">
 <body tal:omit-tag="">
 
-<div id="contentchooser-content-search" class="right ui-widget-content">
+<div id="contentchooser-content-search" class="right ui-widget-content pat-autotoc"
+     data-pat-autotoc="levels: legend; section: fieldset; className: autotabs">
     <div class="close">
         <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
     </div>
-    <ul class="formTabs">
-      <li class="formTab"><a href="#recent" i18n:translate="">Recent items</a></li>
-      <li class="formTab"><a href="#content-tree" i18n:translate="">Content tree</a></li>
-    </ul>
 
-    <div class="panes">
-      <div id="recent" class="tab-pane active">
+      <fieldset id="recent" class="tab-pane active">
+        <legend>Recent Items</legend>
         <div class="input" id="contentchooser-content-search-input-container">
           <input class="contentchooser-content-trees" id="contentchooser-content-search-input" type="text"
             title="Filter items" placeholder="Filter items" name="contentchooser-search"
@@ -33,9 +30,10 @@
         <ul class="item-list"
             tal:replace="structure context/@@content-search">
         </ul>
-      </div>
+      </fieldset>
 
-      <div id="content-trees" class="tab-pane">
+      <fieldset id="content-trees" class="tab-pane">
+          <legend>Content Tree</legend>
           <div class="input" id="contentchooser-content-trees-container">
               <input id="contentchooser-content-trees"
               name="contentchooser-content-trees" type="text" title="Filter items"
@@ -53,8 +51,7 @@
             <li />
           </ul>
 
-      </div>
-    </div>
+      </fieldset>
 
     <div id="contentchooser-content-search-compose-button" style="display: none;"
         i18n:translate="">Add Content</div>

--- a/src/collective/cover/static/js/contentchooser.js
+++ b/src/collective/cover/static/js/contentchooser.js
@@ -321,9 +321,6 @@ var coveractions = {
       hoverClass: 'content-drop-hover ui-state-hover',
       drop: dropped
     });
-
-    // TODO: check if the current contentchooser requires any tabs
-    $(windowId + " ul.formTabs").tabs("div.panes > div");
   }
 
   $(function() {


### PR DESCRIPTION
takes care of the JS `tabs()` error, which break most JS on pages for anonymous users.