### PR TITLE
Issue 745 fix idatetimewidget if ploneappcontenttypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ There's a frood who really knows where his towel is.
 1.6b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix IDatetimeWidget tile override if using plone.app.contenttypes >= 1.1.1:
+  collective.z3cform.datetimewidget is merged into plone.formwidget.datetime,
+  so the zcml must override the template from plone.formwidget.datetime.z3cform.interfaces.IDatetimeWidget
+  as well. (closes `#745`_).
+  [idgserpro]
+
 - Review tile refresh using custom event.
   [rodfersou]
 
@@ -235,3 +241,4 @@ Previous entries can be found in the HISTORY.rst file.
 .. _`#713`: https://github.com/collective/collective.cover/issues/713
 .. _`#721`: https://github.com/collective/collective.cover/issues/721
 .. _`#727`: https://github.com/collective/collective.cover/issues/727
+.. _`#745`: https://github.com/collective/collective.cover/issues/745

--- a/src/collective/cover/tests/test_basic_tile.robot
+++ b/src/collective/cover/tests/test_basic_tile.robot
@@ -44,12 +44,15 @@ Test Basic Tile
 
     Wait Until Page Contains Element  css=${datetimewidget_option_datetime_selector}
     ${datetimewidget_option_datetime_value}  Get Text  css=${datetimewidget_option_datetime_selector}
+    ${datetimewidget_option_datetime_length}  Get Length  ${datetimewidget_option_datetime_value}
 
     Wait Until Page Contains Element  css=${datetimewidget_option_dateonly_selector}
     ${datetimewidget_option_dateonly_value}  Get Text  css=${datetimewidget_option_dateonly_selector}
+    ${datetimewidget_option_dateonly_length}  Get Length  ${datetimewidget_option_dateonly_value}
 
     Wait Until Page Contains Element  css=${datetimewidget_option_timeonly_selector}
     ${datetimewidget_option_timeonly_value}  Get Text  css=${datetimewidget_option_timeonly_selector}
+    ${datetimewidget_option_timeonly_length}  Get Length  ${datetimewidget_option_timeonly_value}
 
     Click Button  Save
 
@@ -70,8 +73,14 @@ Test Basic Tile
     # default: datetime
     Compose Cover
     Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
+    # This logic of comparing the lengths is being used because in some CI environments,
+    # the persisted data in compose_time_value will be different from the data in
+    # the tile of the Compose tab. For example, 
+    # AssertionError: Aug 28, 2017 04:33 PM != Aug 28, 2017 04:31 PM, but the length
+    # would be the same.
     ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
-    Should be equal  ${datetimewidget_option_datetime_value}  ${datetimewidget_compose_time_tag_value}
+    ${datetimewidget_compose_time_tag_length}  Get Length  ${datetimewidget_compose_time_tag_value}
+    Should be equal  ${datetimewidget_option_datetime_length}  ${datetimewidget_compose_time_tag_length}
 
     # dateonly
     Open Layout Tab
@@ -82,7 +91,8 @@ Test Basic Tile
     Compose Cover
     Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
     ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
-    Should be equal  ${datetimewidget_option_dateonly_value}  ${datetimewidget_compose_time_tag_value}
+    ${datetimewidget_compose_time_tag_length}  Get Length  ${datetimewidget_compose_time_tag_value}
+    Should be equal  ${datetimewidget_option_dateonly_length}  ${datetimewidget_compose_time_tag_length}
 
     # timeonly
     Open Layout Tab
@@ -93,7 +103,8 @@ Test Basic Tile
     Compose Cover
     Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
     ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
-    Should be equal  ${datetimewidget_option_timeonly_value}  ${datetimewidget_compose_time_tag_value}
+    ${datetimewidget_compose_time_tag_length}  Get Length  ${datetimewidget_compose_time_tag_value}
+    Should be equal  ${datetimewidget_option_timeonly_length}  ${datetimewidget_compose_time_tag_length}
 
     # return to datetime, again, to test it.
     Open Layout Tab
@@ -104,7 +115,8 @@ Test Basic Tile
     Compose Cover
     Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
     ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
-    Should be equal  ${datetimewidget_option_datetime_value}  ${datetimewidget_compose_time_tag_value}
+    ${datetimewidget_compose_time_tag_length}  Get Length  ${datetimewidget_compose_time_tag_value}
+    Should be equal  ${datetimewidget_option_datetime_length}  ${datetimewidget_compose_time_tag_length}
 
     # drag&drop a File
     Compose Cover

--- a/src/collective/cover/tests/test_basic_tile.robot
+++ b/src/collective/cover/tests/test_basic_tile.robot
@@ -21,6 +21,11 @@ ${news_item_description}  This news item was created for testing purposes
 ${title_field_id}  collective-cover-basic-title
 ${title_sample}  Some text for title
 ${edit_link_selector}  a.edit-tile-link
+${configure_tile_selector}  a.config-tile-link
+${datetimewidget_option_datetime_selector}  select#collective-cover-basic-date-format option[value=datetime]
+${datetimewidget_option_dateonly_selector}  select#collective-cover-basic-date-format option[value=dateonly]
+${datetimewidget_option_timeonly_selector}  select#collective-cover-basic-date-format option[value=timeonly]
+${datetimewidget_compose_time_tag_selector}  div.cover-basic-tile time
 
 *** Test cases ***
 
@@ -34,6 +39,20 @@ Test Basic Tile
     Add Tile  ${basic_tile_location}
     Save Cover Layout
 
+    # Test the customized IDatetimeWidget existence
+    Click Link  css=${configure_tile_selector}
+
+    Wait Until Page Contains Element  css=${datetimewidget_option_datetime_selector}
+    ${datetimewidget_option_datetime_value}  Get Text  css=${datetimewidget_option_datetime_selector}
+
+    Wait Until Page Contains Element  css=${datetimewidget_option_dateonly_selector}
+    ${datetimewidget_option_dateonly_value}  Get Text  css=${datetimewidget_option_dateonly_selector}
+
+    Wait Until Page Contains Element  css=${datetimewidget_option_timeonly_selector}
+    ${datetimewidget_option_timeonly_value}  Get Text  css=${datetimewidget_option_timeonly_selector}
+
+    Click Button  Save
+
     # as tile is empty, we see default message
     Compose Cover
     Page Should Contain   Please drag&drop some content here to populate the tile.
@@ -46,6 +65,46 @@ Test Basic Tile
     # move to the default view and check tile persisted
     Click Link  link=View
     Page Should Contain  My document
+
+    # Test the customized IDatetimeWidget parameters
+    # default: datetime
+    Compose Cover
+    Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
+    ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
+    Should be equal  ${datetimewidget_option_datetime_value}  ${datetimewidget_compose_time_tag_value}
+
+    # dateonly
+    Open Layout Tab
+    Click Link  css=${configure_tile_selector}
+    Wait Until Page Contains Element  css=${datetimewidget_option_dateonly_selector}
+    Click Element  css=${datetimewidget_option_dateonly_selector}
+    Click Button  Save
+    Compose Cover
+    Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
+    ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
+    Should be equal  ${datetimewidget_option_dateonly_value}  ${datetimewidget_compose_time_tag_value}
+
+    # timeonly
+    Open Layout Tab
+    Click Link  css=${configure_tile_selector}
+    Wait Until Page Contains Element  css=${datetimewidget_option_timeonly_selector}
+    Click Element  css=${datetimewidget_option_timeonly_selector}
+    Click Button  Save
+    Compose Cover
+    Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
+    ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
+    Should be equal  ${datetimewidget_option_timeonly_value}  ${datetimewidget_compose_time_tag_value}
+
+    # return to datetime, again, to test it.
+    Open Layout Tab
+    Click Link  css=${configure_tile_selector}
+    Wait Until Page Contains Element  css=${datetimewidget_option_datetime_selector}
+    Click Element  css=${datetimewidget_option_datetime_selector}
+    Click Button  Save
+    Compose Cover
+    Page Should Contain Element  css=${datetimewidget_compose_time_tag_selector}
+    ${datetimewidget_compose_time_tag_value}  Get Text  css=${datetimewidget_compose_time_tag_selector}
+    Should be equal  ${datetimewidget_option_datetime_value}  ${datetimewidget_compose_time_tag_value}
 
     # drag&drop a File
     Compose Cover

--- a/src/collective/cover/tiles/configuration_widgets/configure.zcml
+++ b/src/collective/cover/tiles/configuration_widgets/configure.zcml
@@ -38,9 +38,12 @@
         template="namedimage.pt"
         />
 
-    <!--https://github.com/plone/plone.formwidget.datetime/blob/1.3.1/plone/formwidget/datetime/z3cform/configure.zcml#L77-->
-    <!--This package is used instead of collective.z3cform.datetimewidget if you're-->
-    <!--using plone.app.contenttypes >= 1.1.1.-->
+    <!--BEGIN IDatetimeWidget customization
+        https://github.com/plone/plone.formwidget.datetime/blob/1.3.1/plone/formwidget/datetime/z3cform/configure.zcml#L77
+        This package is used instead of collective.z3cform.datetimewidget if you're
+        using plone.app.contenttypes >= 1.1.1.
+        TODO: Review this IDatetimeWidget customization, check if it's possible to have just on
+        package in all situations. Check https://github.com/collective/collective.cover/issues/747-->
     <z3c:widgetTemplate zcml:condition="installed plone.formwidget.datetime"
         mode="configure"
         widget="plone.formwidget.datetime.z3cform.interfaces.IDatetimeWidget"
@@ -48,12 +51,15 @@
         template="datetime.pt"
         />
 
+    <!--If you don't have plone.app.contenttypes >= 1.1.1 installed, this is used-->
+    <!--instead.-->
     <z3c:widgetTemplate
         mode="configure"
         widget="collective.z3cform.datetimewidget.interfaces.IDatetimeWidget"
         layer="z3c.form.interfaces.IFormLayer"
         template="datetime.pt"
         />
+    <!--END IDatetimeWidget customization-->
 
     <class class=".cssclasswidget.CSSClassWidget">
         <require permission="zope.Public"

--- a/src/collective/cover/tiles/configuration_widgets/configure.zcml
+++ b/src/collective/cover/tiles/configuration_widgets/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:z3c="http://namespaces.zope.org/z3c">
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
     <z3c:widgetTemplate
         mode="configure"
@@ -35,6 +36,16 @@
         widget="plone.formwidget.namedfile.interfaces.INamedImageWidget"
         layer="z3c.form.interfaces.IFormLayer"
         template="namedimage.pt"
+        />
+
+    <!--https://github.com/plone/plone.formwidget.datetime/blob/1.3.1/plone/formwidget/datetime/z3cform/configure.zcml#L77-->
+    <!--This package is used instead of collective.z3cform.datetimewidget if you're-->
+    <!--using plone.app.contenttypes >= 1.1.1.-->
+    <z3c:widgetTemplate zcml:condition="installed plone.formwidget.datetime"
+        mode="configure"
+        widget="plone.formwidget.datetime.z3cform.interfaces.IDatetimeWidget"
+        layer="z3c.form.interfaces.IFormLayer"
+        template="datetime.pt"
         />
 
     <z3c:widgetTemplate


### PR DESCRIPTION
This fixes https://github.com/collective/collective.cover/issues/745, check the issue for more information. This whole collective.z3cform.datetimewidget and plone.formwidget.datetime dependency situation here can be improved in the future by discussing https://github.com/collective/collective.cover/issues/747 and deciding the best approach.

If possible, a new release after merge would be a good idea.