### PR TITLE
Revert declaring cover_layout field in content type schema as readonly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ There's a frood who really knows where his towel is.
 1.6b4 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Revert declaring ``cover_layout`` field in content type schema as ``readonly`` (fixes `#761 https://github.com/collective/collective.cover/issues/761`_).
+  [hvelarde]
 
 
 1.6b3 (2017-10-23)

--- a/src/collective/cover/models/cover.xml
+++ b/src/collective/cover/models/cover.xml
@@ -16,11 +16,13 @@
             <default>Empty layout</default>
         </field>
 
-        <field name="cover_layout" type="zope.schema.Text">
+        <field name="cover_layout" type="zope.schema.Text"
+               form:omitted="z3c.form.interfaces.IForm:true
+                             z3c.form.interfaces.IAddForm:true
+                             z3c.form.interfaces.IEditForm:true">
             <description i18n:translate=""
               >The layout to be used to render groups and tiles</description>
             <title i18n:translate="">Cover Layout</title>
-            <readonly>True</readonly>
         </field>
 
     </schema>

--- a/src/collective/cover/testing.py
+++ b/src/collective/cover/testing.py
@@ -116,11 +116,13 @@ def generate_jpeg(width, height):
 
 
 # FIXME: workaround for https://github.com/plone/plone.app.testing/issues/39
-autoform = ('plone.autoform', {'loadZCML': True})
-tinymce = ('Products.TinyMCE', {'loadZCML': True})
-products = list(PLONE_FIXTURE.products)
-products.insert(products.index(tinymce), autoform)
-PLONE_FIXTURE.products = tuple(products)
+#        Products.TinyMCE is used only in Plone 4
+if not IS_PLONE_5:
+    autoform = ('plone.autoform', {'loadZCML': True})
+    tinymce = ('Products.TinyMCE', {'loadZCML': True})
+    products = list(PLONE_FIXTURE.products)
+    products.insert(products.index(tinymce), autoform)
+    PLONE_FIXTURE.products = tuple(products)
 
 
 class Fixture(PloneSandboxLayer):

--- a/src/collective/cover/testing.py
+++ b/src/collective/cover/testing.py
@@ -115,6 +115,14 @@ def generate_jpeg(width, height):
     return output
 
 
+# FIXME: workaround for https://github.com/plone/plone.app.testing/issues/39
+autoform = ('plone.autoform', {'loadZCML': True})
+tinymce = ('Products.TinyMCE', {'loadZCML': True})
+products = list(PLONE_FIXTURE.products)
+products.insert(products.index(tinymce), autoform)
+PLONE_FIXTURE.products = tuple(products)
+
+
 class Fixture(PloneSandboxLayer):
 
     defaultBases = (PLONE_FIXTURE,)


### PR DESCRIPTION
fixes #761 
refs: https://github.com/plone/plone.app.testing/issues/39