### PR TITLE
Fix mandelbug in robots tests

### DIFF
--- a/src/collective/cover/tests/cover.robot
+++ b/src/collective/cover/tests/cover.robot
@@ -44,7 +44,7 @@ Setup Cover Test Case
 Click Add Cover
     Open Add New Menu
     Click Link  css=a#collective-cover-content
-    Page Should Contain  Add Cover
+    Wait Until Page Contains  Add Cover
 
 Create Cover
     [arguments]  ${title}  ${description}  ${layout}=Empty layout


### PR DESCRIPTION
This fix mandelbug:

    AssertionError: Page should have contained text 'Add Cover' but did not

plonegovbr/brasil.gov.portal#370