### PR TITLE
Provide alternative text for image fields in tiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ There's a frood who really knows where his towel is.
 1.6b6 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Provide alternative text for image fields in tiles (closes `#628 <https://github.com/collective/collective.cover/issues/628>`_).
+  [hvelarde]
 
 
 1.6b5 (2017-11-21)

--- a/src/collective/cover/tests/test_banner_tile.py
+++ b/src/collective/cover/tests/test_banner_tile.py
@@ -94,12 +94,23 @@ class BannerTileTestCase(TestTileMixin, unittest.TestCase):
         self.assertNotIn(msg, self.tile())
 
     def test_render_with_image(self):
+        from lxml import etree
         obj = self.portal['my-image']
         self.tile.populate_with_object(obj)
-        rendered = self.tile()
-        # the image is there and the alt attribute is set
-        self.assertIn('<img ', rendered)
-        self.assertIn('alt="This image was created for testing purposes"', rendered)
+        html = etree.HTML(self.tile())
+        img = html.find('*//img')
+        self.assertIsNotNone(img)
+        self.assertIn('alt', img.attrib)
+        self.assertEqual(img.attrib['alt'], obj.Description())
+
+        # set alternate text
+        alt_text = u'Murciélago hindú'
+        self.tile.data['alt_text'] = alt_text
+        html = etree.HTML(self.tile())
+        img = html.find('*//img')
+        self.assertIsNotNone(img)
+        self.assertIn('alt', img.attrib)
+        self.assertEqual(img.attrib['alt'], alt_text)
 
     def test_render_with_link(self):
         obj = self.portal['my-link']

--- a/src/collective/cover/tests/test_basic_tile.py
+++ b/src/collective/cover/tests/test_basic_tile.py
@@ -156,6 +156,7 @@ class BasicTileTestCase(TestTileMixin, unittest.TestCase):
         self.assertIn('@@images', rendered)
 
     def test_render(self):
+        from lxml import etree
         obj = self.portal['my-news-item']
         obj.setSubject(['subject1', 'subject2'])
         obj.effective_date = DateTime()
@@ -171,6 +172,21 @@ class BasicTileTestCase(TestTileMixin, unittest.TestCase):
         # the description must be there
         self.assertIn(
             '<p>This news item was created for testing purposes</p>', rendered)
+
+        html = etree.HTML(self.tile())
+        img = html.find('*//img')
+        self.assertIsNotNone(img)
+        self.assertIn('alt', img.attrib)
+        self.assertEqual(img.attrib['alt'], obj.Description())
+
+        # set alternate text
+        alt_text = u'Murciélago hindú'
+        self.tile.data['alt_text'] = alt_text
+        html = etree.HTML(self.tile())
+        img = html.find('*//img')
+        self.assertIsNotNone(img)
+        self.assertIn('alt', img.attrib)
+        self.assertEqual(img.attrib['alt'], alt_text)
 
         # the localized time must be there
         date = api.portal.get_localized_time(obj.Date(), long_format=True)

--- a/src/collective/cover/tiles/banner.py
+++ b/src/collective/cover/tiles/banner.py
@@ -3,7 +3,9 @@ from Acquisition import aq_base
 from collective.cover import _
 from collective.cover.tiles.base import IPersistentCoverTile
 from collective.cover.tiles.base import PersistentCoverTile
+from collective.cover.tiles.configuration_view import IDefaultConfigureForm
 from collective.cover.utils import get_types_use_view_action_in_listings
+from plone.autoform import directives as form
 from plone.namedfile import field
 from plone.tiles.interfaces import ITileDataManager
 from plone.uuid.interfaces import IUUID
@@ -25,12 +27,23 @@ class IBannerTile(IPersistentCoverTile):
         required=False,
     )
 
-    remote_url = schema.TextLine(
+    form.omitted(IDefaultConfigureForm, 'alt_text')
+    alt_text = schema.TextLine(
+        title=_(
+            u'label_alt_text',
+            default=u'Alternative Text'),
+        description=_(
+            u'help_alt_text',
+            default=u'Provides a textual alternative to non-text content in web pages.'),  # noqa E501
+        required=False,
+    )
+
+    remote_url = schema.TextLine(  # FIXME: this must be schema.URI()
         title=_(u'URL'),
         required=False,
     )
 
-    uuid = schema.TextLine(
+    uuid = schema.TextLine(  # FIXME: this must be schema.ASCIILine()
         title=_(u'UUID'),
         required=False,
         readonly=True,
@@ -82,6 +95,8 @@ class BannerTile(PersistentCoverTile):
             'description': description,
             'uuid': IUUID(obj),
             'image': image,
+            # FIXME: https://github.com/collective/collective.cover/issues/778
+            'alt_text': description or title,
             'remote_url': remote_url,
         })
 
@@ -110,5 +125,6 @@ class BannerTile(PersistentCoverTile):
 
     @property
     def alt(self):
-        """Return the alt attribute for the image."""
-        return self.data.get('description') or self.data.get('title')
+        """Return alternative text dealing with form init issues."""
+        alt_text = self.data['alt_text']
+        return alt_text if alt_text is not None else u''


### PR DESCRIPTION
- [x] banner tile
- [x] basic tile
- [x] others? (other tiles just reference objects)

closes #628 