### PR TITLE
Remove unnecessary image check to avoid mandelbug.

### DIFF
--- a/src/collective/cover/tests/test_basic_tile.robot
+++ b/src/collective/cover/tests/test_basic_tile.robot
@@ -149,7 +149,6 @@ Test Basic Tile
     Compose Cover
     Open Content Chooser
     Drag And Drop  css=${image_selector}  css=${tile_selector}
-    Wait Until Page Contains Element  css=div.cover-basic-tile a img
     Wait Until Page Contains  Internal Server Error
     Remove Patch Populate With Object
 


### PR DESCRIPTION
Sometimes internal server error occurs before the image is loaded.

Avoid:
https://travis-ci.org/collective/collective.cover/jobs/415709476#L1748