### PR TITLE
Solve_issue_868

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ There's a frood who really knows where his towel is.
 ^^^^^^^^^^^^^^^^^^
 
 - The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_). [Mubra]
-
+-A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_). [Mubra]
 
 2.2.0 (2019-02-26)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ There's a frood who really knows where his towel is.
 2.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- solve issue #861.
+- The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes # 861). [Mubra]
 
 
 2.2.0 (2019-02-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog
 
 There's a frood who really knows where his towel is.
 
+2.2.1 (unreleased)
+^^^^^^^^^^^^^^^^^^
+
+- Nothing changed yet.
+
+
 2.2.0 (2019-02-26)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ There's a frood who really knows where his towel is.
 2.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes # 861). [Mubra]
+- The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_). [Mubra]
 
 
 2.2.0 (2019-02-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ There's a frood who really knows where his towel is.
 2.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- solve issue #861.
 
 
 2.2.0 (2019-02-26)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.2.0'
+version = '2.2.1.dev0'
 description = 'A sane, working, editor-friendly way of creating front pages and other composite pages. Working now, for mere mortals.'
 long_description = (
     open('README.rst').read() + '\n' +

--- a/webpack/app/js/layout.js
+++ b/webpack/app/js/layout.js
@@ -301,6 +301,8 @@ export default class LayoutView {
       }
       new_tile.append(name_tag);
 
+      //the element is taken based on the 'drop' event
+      column_elem = e.target;
       $(column_elem).append(new_tile);
       this.delete_manager(new_tile);
 

--- a/webpack/app/js/layout.js
+++ b/webpack/app/js/layout.js
@@ -236,7 +236,10 @@ export default class LayoutView {
 
     //allow columns droppable
     let onDrop = function(e, ui) {
-      this.row_drop(rows);
+        //the origin row is taken with the "drop" event
+	let helprows = this.row_dom.clone();
+	helprows['0']=e.target;
+	this.row_drop(helprows);
     };
     rows.droppable({
       activeClass: 'ui-state-default',


### PR DESCRIPTION
ambiguity is generated between previously saved items. It was corrected by creating a "row" element and modifying its structure with the even "drop.target" to avoid ambiguity

![solve2](https://user-images.githubusercontent.com/46692684/66002567-99877080-e469-11e9-9fd8-36821d4fcfb3.gif)
