### PR TITLE
Solve_issue_868 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,11 @@ There's a frood who really knows where his towel is.
 2.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_). [Mubra]
+- A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_).
+[Mubra]
 
-- The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_). [Mubra]
+- The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_).
+[Mubra]
 
 
 2.2.0 (2019-02-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ There's a frood who really knows where his towel is.
 
 - The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_). [Mubra]
 
+- A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_). [Mubra]
 
 2.2.0 (2019-02-26)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,10 @@ There's a frood who really knows where his towel is.
 ^^^^^^^^^^^^^^^^^^
 
 - A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_).
-[Mubra]
+  [Mubra]
 
 - The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_).
-[Mubra]
+  [Mubra]
 
 
 2.2.0 (2019-02-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,10 @@ There's a frood who really knows where his towel is.
 2.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_). [Mubra]
+
 - The 'drop' event and its 'target' method are used to obtain the element (column) and not generate ambiguity (fixes `#861 <https://github.com/collective/collective.cover/issues/861>`_). [Mubra]
 
-- A "row" object is generated and its location in the DOM is added with the even "drop.target" (fixes `#868 <https://github.com/collective/collective.cover/issues/868>`_). [Mubra]
 
 2.2.0 (2019-02-26)
 ^^^^^^^^^^^^^^^^^^

--- a/webpack/app/js/layout.js
+++ b/webpack/app/js/layout.js
@@ -236,10 +236,10 @@ export default class LayoutView {
 
     //allow columns droppable
     let onDrop = function(e, ui) {
-        //the origin row is taken with the "drop" event
-	let helprows = this.row_dom.clone();
-	helprows['0']=e.target;
-	this.row_drop(helprows);
+      //the origin row is taken with the "drop" event
+      let helprows = this.row_dom.clone();
+      helprows['0']=e.target;
+      this.row_drop(helprows);
     };
     rows.droppable({
       activeClass: 'ui-state-default',

--- a/webpack/app/js/layout.js
+++ b/webpack/app/js/layout.js
@@ -236,7 +236,10 @@ export default class LayoutView {
 
     //allow columns droppable
     let onDrop = function(e, ui) {
-      this.row_drop(rows);
+        //the origin row is taken with the "drop" event
+	let helprows = this.row_dom.clone();
+	helprows['0']=e.target;
+	this.row_drop(helprows);
     };
     rows.droppable({
       activeClass: 'ui-state-default',


### PR DESCRIPTION
ambiguity is generated between previously saved items. It was corrected by creating a "row" element and modifying its structure with the even "drop.target" to avoid ambiguity.

![solve2](https://user-images.githubusercontent.com/46692684/66009852-f3943000-e481-11e9-935f-71986f649558.gif)

closes #868