### PR TITLE
Fix robot tests

### DIFF
--- a/src/collective/cover/tests/cover.robot
+++ b/src/collective/cover/tests/cover.robot
@@ -5,9 +5,6 @@ Variables  plone/app/testing/interfaces.py
 
 *** Variables ***
 
-${PORT} =  55001
-${ZOPE_URL} =  http://localhost:${PORT}
-${PLONE_URL} =  ${ZOPE_URL}/plone
 ${BROWSER} =  Firefox
 
 ${title_selector} =  input#form-widgets-IBasic-title

--- a/src/collective/cover/tests/cover.robot
+++ b/src/collective/cover/tests/cover.robot
@@ -13,30 +13,13 @@ ${layout_selector} =  select#form-widgets-template_layout
 
 ${row_button_selector} =  a#btn-row
 ${column_button_selector} =  a#btn-column
-${tile_button_selector} =  a#btn-tile
 ${row_drop_area_selector} =  div.layout
-${column_drop_area_selector} =  div.cover-row
 ${tile_drop_area_selector} =  div.cover-column
 ${tile_cancel_area_selector} =  div.modal-backdrop
 ${delete_tile_selector} =  button.close
 ${CONTENT_CHOOSER_SELECTOR} =  div#contentchooser-content-search
 
 *** Keywords ***
-
-Start Browser and Autologin as
-    [arguments]  ${role}
-
-    Open Test Browser
-    Enable Autologin as  $role
-
-Start Browser and Log In as Site Owner
-    Open Test Browser
-    Log In As Site Owner
-    Click Link  link=Home
-
-Setup Cover Test Case
-    Start Browser and Log In as Site Owner
-    Go to Homepage
 
 Click Add Cover
     Open Add New Menu

--- a/src/collective/cover/tests/test_locked_cover.robot
+++ b/src/collective/cover/tests/test_locked_cover.robot
@@ -16,6 +16,26 @@ ${basic_tile_location}  'collective.cover.basic'
 ${document_selector}  .ui-draggable .contenttype-document
 ${tile_selector}  div.tile-container div.tile
 
+
+*** Keywords ***
+
+# FIXME: Override the plone.app.robotframework 'Log in' keyword.
+# The original keyword doesn't work in Plone 4.3. 
+# See: https://github.com/plone/plone.app.robotframework/issues/107
+Log in
+    [Documentation]  Log in to the site as ${userid} using ${password}. There
+    ...              is no guarantee of where in the site you are once this is
+    ...              done. (You are responsible for knowing where you are and
+    ...              where you want to be)
+    [Arguments]  ${userid}  ${password}
+    Go to  ${PLONE_URL}/login_form
+    Page should contain element  __ac_name
+    Page should contain element  __ac_password
+    Page should contain element  css=#login-form .formControls input[name=submit]
+    Input text for sure  __ac_name  ${userid}
+    Input text for sure  __ac_password  ${password}
+    Click Button  css=#login-form .formControls input[name=submit]
+
 *** Test Cases ***
 
 Test Locked Cover

--- a/src/collective/cover/tests/test_reverse_proxy.robot
+++ b/src/collective/cover/tests/test_reverse_proxy.robot
@@ -30,7 +30,7 @@ Test Reverse Proxy
     Compose Cover
     Page Should Contain   Please drag&drop some content here to populate the tile.
 
-    Open Browser  http://localhost:${PORT}/VirtualHostBase/http/127.0.0.1:${PORT}/plone/VirtualHostRoot/_vh_subplone/title-1
+    Open Browser  http://localhost:${ZOPE_PORT}/VirtualHostBase/http/127.0.0.1:${ZOPE_PORT}/plone/VirtualHostRoot/_vh_subplone/title-1
     Page Should Not Contain   Please drag&drop some content here to populate the tile.
 
     Switch Browser  1


### PR DESCRIPTION
Don't override `ZOPE_URL` and `PLONE_URL` variables. Now `plone.app.robotframework` define `ZOPE_PORT` dynamically. Isn't possible change the port.

This avoids the error:

```
[ ERROR ] Error in file
'/home/travis/build/collective/collective.cover/src/collective/cover/tests/test_embed_tile.robot':
Getting keyword names from library 'Remote' failed: Calling dynamic
method 'get_keyword_names' failed: Connecting remote server at
http://localhost:55001/plone/RobotRemote failed: [Errno 111] Connection refused
```
This error started to occur after Plone version 4.3.19.