### PR TITLE
Set TZ environment variables in tests to avoid test errors

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -79,5 +79,9 @@ recipe = sc.recipe.staticresources
 name = collective.cover
 short_name = cover
 
+[test]
+initialization +=
+    os.environ['TZ'] = 'UTC'
+
 [versions]
 sc.recipe.staticresources = 1.1b5


### PR DESCRIPTION
`tzlocal` 2.0.0 verifies that the timezone it fouds has the same offset as
the local computer is configured with.If not, it raise the error:

```
ValueError: Timezone offset does not match system offset: -7200 !=
-10800. Please, check your config files.
```

Setting TZ environment variable, this check is no longer done.

Ref: https://github.com/regebro/tzlocal/issues/74