### PR TITLE
Remove pinning of plone.api on Plone 4.3

### DIFF
--- a/versions-4.3.x.cfg
+++ b/versions-4.3.x.cfg
@@ -13,6 +13,3 @@ plone.tiles = 2.1
 
 # XXX: PFG tile is deprecated and will be removed in collective.cover 3
 Products.PloneFormGen = <1.8.0.alpha1
-
-# XXX: must be clean up after new Plone versions
-plone.api = >=1.8.5


### PR DESCRIPTION
Plone 4.3.19 already has plone.api >= 1.8.5