### PR TITLE
Fixed changing the order in a list tile by drag and drop.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ There's a frood who really knows where his towel is.
 2.2.3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Fixed changing the order in a list tile by drag and drop.
+  [maurits]
 
 
 2.2.2 (2019-12-27)

--- a/webpack/app/js/compose.js
+++ b/webpack/app/js/compose.js
@@ -148,11 +148,12 @@ export default class ComposeView {
       return;
     }
     let onStop = function(e, ui) {
-      let $el = $(e.currentTarget);
       let uuids = [];
-      $(e.currentTarget).children().each(function(index) {
-        if ($el.attr('data-content-uuid') !== undefined) {
-          uuids.push($el.attr('data-content-uuid'));
+      // We iterate over the children of the original $el determined at the top of onMouseOverSortable.
+      $el.children().each(function(index) {
+        let child = $($el.children()[index]);
+        if (child.attr('data-content-uuid') !== undefined) {
+          uuids.push(child.attr('data-content-uuid'));
         }
       });
       let tile = $el.closest('.tile');


### PR DESCRIPTION
Changing the order in a list tile on the Compose tab would seemingly work at first, but nothing was saved.
The wrong element was taken as base (the whole html document instead of the tile).
And iterating over the children to get their uuids was done wrong, trying to take a uuid attribute from always that same wrong element.

Tested in Plone 4.3 and 5.1.
