### PR TITLE
Remove customized robot keyword 'Log in'

### DIFF
--- a/src/collective/cover/tests/test_locked_cover.robot
+++ b/src/collective/cover/tests/test_locked_cover.robot
@@ -16,26 +16,6 @@ ${basic_tile_location}  'collective.cover.basic'
 ${document_selector}  .ui-draggable .contenttype-document
 ${tile_selector}  div.tile-container div.tile
 
-
-*** Keywords ***
-
-# FIXME: Override the plone.app.robotframework 'Log in' keyword.
-# The original keyword doesn't work in Plone 4.3. 
-# See: https://github.com/plone/plone.app.robotframework/issues/107
-Log in
-    [Documentation]  Log in to the site as ${userid} using ${password}. There
-    ...              is no guarantee of where in the site you are once this is
-    ...              done. (You are responsible for knowing where you are and
-    ...              where you want to be)
-    [Arguments]  ${userid}  ${password}
-    Go to  ${PLONE_URL}/login_form
-    Page should contain element  __ac_name
-    Page should contain element  __ac_password
-    Page should contain element  css=#login-form .formControls input[name=submit]
-    Input text for sure  __ac_name  ${userid}
-    Input text for sure  __ac_password  ${password}
-    Click Button  css=#login-form .formControls input[name=submit]
-
 *** Test Cases ***
 
 Test Locked Cover


### PR DESCRIPTION
Plone 4.3.20 pinned plone.app.robotframework 1.2.4, which fixes
https://github.com/plone/plone.app.robotframework/issues/107