### PR TITLE
Update versions of setuptools/buildout

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -86,5 +86,5 @@ initialization +=
 [versions]
 sc.recipe.staticresources = 1.1b5
 # Keep the same as in requirements.txt:
-setuptools = 40.8.0
-zc.buildout = 2.13.1
+setuptools = 42.0.2
+zc.buildout = 2.13.3


### PR DESCRIPTION
These are the versions used by the new release of Plone 5.1