### PR TITLE
Update node version to 14.15.4

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -70,7 +70,7 @@ scripts =
 
 [node]
 recipe = gp.recipe.node
-version = 8.11.2
+version = 14.15.4
 npms = npm yarn
 scripts = npm yarn
 


### PR DESCRIPTION
New versions of some node packages are not compatible with old versions of the node.

Avoid error:

```bash
TypeError: Cannot destructure property `stat` of 'undefined' or 'null'.
```