### PR TITLE
Fix calendar tile in Plone 5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Apply patch in ``Products.ZCatalog.query.IndexQuery``, to avoid error when clicking on a day with event in the calendar tile.
+  [wesleybl]
+
 - Fix calendar tile in Plone 5.2 (fixes `#633 <https://github.com/collective/collective.cover/issues/633>`_).
   [wesleybl, pbauer]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix calendar tile in Plone 5.2 (fixes `#633 <https://github.com/collective/collective.cover/issues/633>`_).
+  [wesleybl, pbauer]
+
 - Remove old upgrade steps.
   [wesleybl]
 

--- a/src/collective/cover/__init__.py
+++ b/src/collective/cover/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from collective.cover import patches
 from zope.i18nmessageid import MessageFactory
 
 
 _ = MessageFactory("collective.cover")
+
+patches.run()

--- a/src/collective/cover/patches.py
+++ b/src/collective/cover/patches.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from collective.cover.logger import logger
+from Products.ZCatalog.query import IndexQuery
+from ZPublisher.HTTPRequest import record
+
+
+def index_query():
+    # FIXME: Remove this patch after fixing:
+    # https://github.com/plone/Products.CMFPlone/issues/3007
+    def patched_init(
+        self, request, iid, options=(), operators=("or", "and"), default_operator="or"
+    ):
+        """Patch original __init__"""
+        if iid in request:
+            param = request[iid]
+            # IndexQuery expects the param to be a dictionary, to extract the
+            # 'query' key. See:
+            # https://github.com/zopefoundation/Products.ZCatalog/blob/91e7826dcfd196632fb1c9318cd5025b718f1058/src/Products/ZCatalog/query.py#L68
+            # However, when we use record notation in the URL, for example:
+            # http://localhost:8080/Plone/@@search?end.query:record:list:date=2022-2-2+00%3A00%3A00&end.range:record=min
+            # the parameter becomes a record and not a dictionary.
+            # If we don't convert from record to dict, the query key is not extracted,
+            # causing the error:
+            # TypeError: unhashable type: 'record'
+            # See:
+            # https://github.com/plone/Products.CMFPlone/issues/3007
+            if isinstance(param, record):
+                request[iid] = dict(param)
+        return self.__orig_init__(request, iid, options, operators, default_operator)
+
+    setattr(
+        IndexQuery,
+        "__orig_init__",
+        IndexQuery.__init__,
+    )
+    setattr(IndexQuery, "__init__", patched_init)
+
+    logger.info("Patched Products.ZCatalog.query.IndexQuery")
+
+
+def run():
+    index_query()

--- a/src/collective/cover/testing.py
+++ b/src/collective/cover/testing.py
@@ -125,7 +125,7 @@ class Fixture(PloneSandboxLayer):
 
         portal_workflow = portal.portal_workflow
         portal_workflow.setChainForPortalTypes(
-            ["Collection"], ["simple_publication_workflow"]
+            ["Collection", "Event"], ["simple_publication_workflow"]
         )
 
 

--- a/src/collective/cover/tests/test_calendar_tile.py
+++ b/src/collective/cover/tests/test_calendar_tile.py
@@ -2,6 +2,7 @@
 from collective.cover.tests.base import TestTileMixin
 from collective.cover.tiles.calendar import CalendarTile
 from collective.cover.tiles.calendar import ICalendarTile
+from plone import api
 
 import unittest
 
@@ -26,3 +27,17 @@ class CalendarTileTestCase(TestTileMixin, unittest.TestCase):
 
     def test_accepted_content_types(self):
         self.assertEqual(self.tile.accepted_ct(), [])
+
+    def get_today_events(self, events):
+        for week in events:
+            for day in week:
+                if "is_today" in day and day["is_today"]:
+                    return day
+
+    def test_getevents_for_calendar_first_weekday_6(self):
+        api.portal.set_registry_record("plone.first_weekday", 6)
+        with api.env.adopt_roles(["Manager"]):
+            api.content.transition(self.portal["my-event"], "publish")
+        events = self.tile.getEventsForCalendar()
+        today_events = self.get_today_events(events)
+        self.assertEqual(today_events["eventslist"][0]["title"], "My event")

--- a/src/collective/cover/tiles/calendar.py
+++ b/src/collective/cover/tiles/calendar.py
@@ -337,9 +337,7 @@ class CalendarTile(PersistentCoverTile):
     def getReviewStateString(self):
         states = self.calendar_states
         return "".join(
-            map(
-                lambda x: "review_state={0}&amp;".format(self.url_quote_plus(x)), states
-            )
+            map(lambda x: "review_state={0}".format(self.url_quote_plus(x)), states)
         )
 
     def getEventTypes(self):

--- a/src/collective/cover/tiles/calendar.py
+++ b/src/collective/cover/tiles/calendar.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from Acquisition import aq_inner
 from collective.cover import _
 from collective.cover.tiles.base import IPersistentCoverTile
@@ -45,6 +47,8 @@ class CalendarTile(PersistentCoverTile):
         context = aq_inner(self.context)
         self._ts = getToolByName(context, "translation_service")
         self.url_quote_plus = quote_plus
+
+        self.first_weekday = api.portal.get_registry_record("plone.first_weekday")
 
         self.now = localtime()
         self.yearmonth = yearmonth = self.getYearAndMonthToDisplay()
@@ -111,9 +115,8 @@ class CalendarTile(PersistentCoverTile):
         #  [14, 15, 16, 17, 18, 19, 20],
         #  [21, 22, 23, 24, 25, 26, 27],
         #  [28, 29, 30, 31, 0, 0, 0]]
-        first_weekday = api.portal.get_registry_record("plone.first_weekday") + 1
 
-        calendar.setfirstweekday(first_weekday)
+        calendar.setfirstweekday(self.first_weekday)
         daysByWeek = calendar.monthcalendar(year, month)
         weeks = []
 
@@ -307,8 +310,9 @@ class CalendarTile(PersistentCoverTile):
     def getWeekdays(self):
         """Returns a list of Messages for the weekday names."""
         weekdays = []
-        first_weekday = api.portal.get_registry_record("plone.first_weekday") + 1
-        day_numbers = [i % 7 for i in range(first_weekday, first_weekday + 7)]
+        # In TranslationServiceTool, Sunday is 0. So we need to add +1 to first_weekday.
+        first_weekday_ts = self.first_weekday + 1
+        day_numbers = [i % 7 for i in range(first_weekday_ts, first_weekday_ts + 7)]
 
         # list of ordered weekdays as numbers
         for day in day_numbers:

--- a/src/collective/cover/tiles/templates/calendar.pt
+++ b/src/collective/cover/tiles/templates/calendar.pt
@@ -67,7 +67,7 @@
                           tal:attributes="class python:is_today and 'todayevent' or 'event'">
                         <strong>
                           <a href=""
-                              tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&amp;${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23%3A59%3A59&amp;start.range:record=max&amp;end.query:record:list:date=${day/date_string}+00%3A00%3A00&amp;end.range:record=min&amp;list:&amp;${view/getEventTypes};
+                              tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&amp;${view/getReviewStateString}&amp;start.query:record:list:date=${day/date_string}+23%3A59%3A59&amp;start.range:record=max&amp;end.query:record:list:date=${day/date_string}+00%3A00%3A00&amp;end.range:record=min&amp;list:&amp;${view/getEventTypes};
                                               title day/eventstring;"
                               tal:content="daynumber">31</a>
                         </strong>


### PR DESCRIPTION
With these changes, the calendar tile now works in `Plone 5.2`.

Patch in `Products.ZCatalog.query.IndexQuery` should be removed after fix: 

https://github.com/plone/Products.CMFPlone/issues/3007

See commit descriptions for more details.

fixes #633 