### PR TITLE
Fix PicklingError when editing basic tile that contains an image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix PicklingError when editing basic tile that contains an image (fixes `#907 <https://github.com/collective/collective.cover/issues/907>`_).
+  [wesleybl]
+
 - Reorganizes the js events register in Compose when we drag content from one tile to
   another, in order to prevent the content from remaining on the source tile.
   [wesleybl]

--- a/src/collective/cover/tiles/edit.py
+++ b/src/collective/cover/tiles/edit.py
@@ -12,6 +12,7 @@ from plone.tiles.interfaces import ITileDataManager
 from plone.z3cform.interfaces import IDeferSecurityCheck
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
+from z3c.form import form
 from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserView
@@ -56,10 +57,12 @@ class CustomEditForm(DefaultEditForm):
         # We need to check first for existing content in order not not loose
         # fields that weren't sent with the form
         dataManager = ITileDataManager(tile)
-        old_data = dataManager.get()
-        for item in data:
-            old_data[item] = data[item]
-        dataManager.set(old_data)
+        # Get the current data and apply changes to it.
+        new_data = dataManager.get()
+        form.applyChanges(self, new_data, data)
+        for group in self.groups:
+            form.applyChanges(group, new_data, data)
+        dataManager.set(new_data)
 
         api.portal.show_message(_(u"Tile saved"), self.request, type="info")
 


### PR DESCRIPTION
Using `applyChanges` as is done in plone.app.tiles fixes the problem. See:

https://github.com/plone/plone.app.tiles/blob/b87450b0c7eff38b224f3306e0bbfc20d3a48e12/plone/app/tiles/browser/edit.py#L113-L119

Fixes #907 