### PR TITLE
Fix WrongContainedType when editing a carousel tile

### DIFF
--- a/src/collective/cover/tests/test_carousel_tile.py
+++ b/src/collective/cover/tests/test_carousel_tile.py
@@ -106,7 +106,7 @@ class CarouselTileTestCase(TestTileMixin, unittest.TestCase):
 
         self.assertTrue(isinstance(uuids, dict))
         self.assertTrue(len(uuids) == 1)
-        self.assertTrue(uuids[obj1.UID()]["order"] == 0)
+        self.assertTrue(uuids[obj1.UID()]["order"] == u"0")
 
         # now we add a second image
         obj2 = self.portal["my-image1"]
@@ -117,8 +117,8 @@ class CarouselTileTestCase(TestTileMixin, unittest.TestCase):
 
         self.assertTrue(isinstance(uuids, dict))
         self.assertTrue(len(uuids) == 2)
-        self.assertTrue(uuids[obj1.UID()]["order"] == 0)
-        self.assertTrue(uuids[obj2.UID()]["order"] == 1)
+        self.assertTrue(uuids[obj1.UID()]["order"] == u"0")
+        self.assertTrue(uuids[obj2.UID()]["order"] == u"1")
 
     def test_custom_title(self):
         # we start with an empty tile
@@ -202,9 +202,9 @@ class CarouselTileTestCase(TestTileMixin, unittest.TestCase):
         conv = UUIDSFieldDataConverter(field, widget)
 
         value = {
-            u"uuid1": {u"order": 0},
-            u"uuid2": {u"order": 2},
-            u"uuid3": {u"order": 1},
+            u"uuid1": {u"order": u"0"},
+            u"uuid2": {u"order": u"2"},
+            u"uuid3": {u"order": u"1"},
         }
 
         to_widget = conv.toWidgetValue(value)

--- a/src/collective/cover/tests/test_textlinessortable_widget.py
+++ b/src/collective/cover/tests/test_textlinessortable_widget.py
@@ -143,10 +143,10 @@ class TestTextLinesSortableWidget(unittest.TestCase):
         expected = {
             obj1.UID(): {
                 u"custom_url": u"custom_url",
-                u"order": 0,
+                u"order": u"0",
             },
-            obj2.UID(): {u"order": 2},
-            obj3.UID(): {u"order": 1},
+            obj2.UID(): {u"order": u"2"},
+            obj3.UID(): {u"order": u"1"},
         }
 
         extracted_value = widget.extract()
@@ -181,14 +181,14 @@ class TestTextLinesSortableWidget(unittest.TestCase):
         widget.name = name
         widget.context = {
             "uuids": {
-                obj1.UID(): {u"order": 0, u"custom_description": u"áéíóú"},
-                obj2.UID(): {u"order": 1, u"custom_description": u""},
+                obj1.UID(): {u"order": u"0", u"custom_description": u"áéíóú"},
+                obj2.UID(): {u"order": u"1", u"custom_description": u""},
             },
         }
 
         expected = {
-            obj1.UID(): {u"order": 0},
-            obj2.UID(): {u"order": 1},
+            obj1.UID(): {u"order": u"0"},
+            obj2.UID(): {u"order": u"1"},
         }
 
         extracted_value = widget.extract()

--- a/src/collective/cover/tiles/configuration.py
+++ b/src/collective/cover/tiles/configuration.py
@@ -2,7 +2,6 @@
 from persistent.dict import PersistentDict
 from plone.namedfile.interfaces import INamedBlobImageField
 from plone.tiles.interfaces import ITileType
-from Products.CMFPlone.utils import safe_text
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.interface import implementer
@@ -12,6 +11,8 @@ from zope.schema import getFieldsInOrder
 from zope.schema.interfaces import IDatetime
 from zope.schema.interfaces import IInt
 from zope.schema.interfaces import ITextLine
+
+import six
 
 
 ANNOTATIONS_KEY_PREFIX = u"plone.tiles.configuration"
@@ -104,7 +105,7 @@ class TilesConfigurationScreen(object):
         fields = getFieldNamesInOrder(tile_type.schema)
 
         for name, field in getFieldsInOrder(tile_type.schema):
-            order = safe_text(fields.index(name))
+            order = six.text_type(fields.index(name))
             # default configuration attributes for all fields
             defaults[name] = {"order": order, "visibility": u"on"}
             if name == "css_class":

--- a/src/collective/cover/tiles/list.py
+++ b/src/collective/cover/tiles/list.py
@@ -14,7 +14,6 @@ from plone.namedfile.field import NamedBlobImage
 from plone.tiles.interfaces import ITileDataManager
 from plone.tiles.interfaces import ITileType
 from plone.uuid.interfaces import IUUID
-from Products.CMFPlone.utils import safe_text
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope import schema
 from zope.component import queryUtility
@@ -22,6 +21,7 @@ from zope.interface import implementer
 from zope.schema import getFieldsInOrder
 
 import logging
+import six
 
 
 logger = logging.getLogger(PROJECTNAME)
@@ -208,7 +208,7 @@ class ListTile(PersistentCoverTile):
         for uuid in uuids:
             if uuid not in uuids_dict:
                 entry = dict()
-                entry[u"order"] = safe_text(order)
+                entry[u"order"] = six.text_type(order)
                 uuids_dict[uuid] = entry
                 order += 1
 

--- a/src/collective/cover/tiles/list.py
+++ b/src/collective/cover/tiles/list.py
@@ -196,7 +196,7 @@ class ListTile(PersistentCoverTile):
             # Do not allow adding more objects than the defined limit
             return
 
-        order_list = [int(val.get("order", 0)) for key, val in uuids_dict.items()]
+        order_list = [int(val.get("order", 0)) for val in uuids_dict.values()]
         if len(order_list) == 0:
             # First entry
             order = 0

--- a/src/collective/cover/widgets/textlinessortable.py
+++ b/src/collective/cover/widgets/textlinessortable.py
@@ -10,6 +10,8 @@ from z3c.form.browser import textlines
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.interface import implementer
 
+import six
+
 
 @implementer(ITextLinesSortableWidget)
 class TextLinesSortableWidget(textlines.TextLinesWidget):
@@ -131,7 +133,7 @@ class TextLinesSortableWidget(textlines.TextLinesWidget):
         results = dict()
         for index, uuid in enumerate(uuids):
             obj = uuidToObject(uuid)
-            results[uuid] = {u"order": safe_text(index)}
+            results[uuid] = {u"order": six.text_type(index)}
             custom_title = self.request.get(
                 "{0}.custom_title.{1}".format(self.name, uuid), ""
             )


### PR DESCRIPTION
The problem was that the key `order` of the `uuids` field was coming in as an int, when it should actually be a string. To see:

https://github.com/collective/collective.cover/blob/cb13a1c9f7094c237f697c1e1a81bf35ce39feeb/src/collective/cover/tiles/list.py#L37

In the migration to Python 3, the `order` field assignment was changed from:

```python
six.text_type(order)
```

to

```python
safe_unicode(order)
```
To see:

https://github.com/collective/collective.cover/commit/82c873b5bedd5a315149faf4112c244bbafe018a#diff-5736af52418c00117a6e6820d0dad4c838000e46066e775a0811421a2f10ac90L211-R2

However, `safe_unicode(order)` does not transform an int into a string, like `six.text_type(order)`.

Then we use `six.text_type(order)` in the order field assignment.

Fixes #909 
