### PR TITLE
Fix drag and drop in Compose

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Reorganizes the js events register in Compose when we drag content from one tile to
+  another, in order to prevent the content from remaining on the source tile.
+  [wesleybl]
+
 - In ``PersistentCoverTileDataManager`` set, purge tile after put values into storage to
   prevent old values from being cache, since purge accesses ``tile.data``.
   Also updated the attribute where data is saved for ``self.storage``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- In ``PersistentCoverTileDataManager`` set, purge tile after put values into storage to
+  prevent old values from being cache, since purge accesses ``tile.data``.
+  Also updated the attribute where data is saved for ``self.storage``.
+  [wesleybl]
+
 - Show Cover in navbar.
   [wesleybl]
 

--- a/src/collective/cover/tiles/base.py
+++ b/src/collective/cover/tiles/base.py
@@ -422,7 +422,7 @@ class PersistentCoverTile(ESIPersistentTile):
         from collective.cover.browser.scaling import AnnotationStorage
 
         storage = AnnotationStorage(self)
-        for key in storage.keys():
+        for key in list(storage):
             try:
                 del storage[key]
             except KeyError:

--- a/webpack/app/js/compose.js
+++ b/webpack/app/js/compose.js
@@ -147,42 +147,7 @@ export default class ComposeView {
     if ($el.data('init')) {
       return;
     }
-    let onStop = function(e, ui) {
-      let uuids = [];
-      // We iterate over the children of the original $el determined at the top of onMouseOverSortable.
-      $el.children().each(function(index) {
-        let child = $($el.children()[index]);
-        if (child.attr('data-content-uuid') !== undefined) {
-          uuids.push(child.attr('data-content-uuid'));
-        }
-      });
-      let tile = $el.closest('.tile');
-      let tile_type = tile.attr('data-tile-type');
-      let tile_id = tile.attr('id');
-      $.ajax({
-        url: '@@updatelisttilecontent',
-        context: this,
-        data: {
-          'tile-type': tile_type,
-          'tile-id': tile_id,
-          'uuids': uuids
-        },
-        success: function(info) {
-          tile.html(info);
-          tile.trigger('change');
-          this.update();
-          return false;
-        },
-        error: function(XMLHttpRequest, textStatus, errorThrown) {
-          tile.html(textStatus + ': ' + errorThrown);
-          this.update();
-          return false;
-        }
-      });
-    };
-    $el.data('init', true).sortable({
-      stop: onStop.bind(this),
-    });
+    $el.data('init', true).sortable();
   }
   onRemoveClick(e) {
     e.preventDefault();


### PR DESCRIPTION
- Fix RuntimeError when dropping an image from a list tile to a banner tile.
- In ``PersistentCoverTileDataManager`` set, purge tile after put values into storage to prevent old values from being cache, since purge accesses ``tile.data``. Also updated the attribute where data is saved for ``self.storage``.
- Reorganizes the js events register in Compose when we drag content from one tile to another, in order to prevent the content from remaining on the source tile.

Fixes #914 