### PR TITLE
Unlock Cover when editor leaves Compose/Layout tabs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Unlock Cover when editor leaves Compose/Layout tabs (fixes `#916 <https://github.com/collective/collective.cover/issues/916>`_).
+  [wesleybl]
+
 - Fix PicklingError when editing basic tile that contains an image (fixes `#907 <https://github.com/collective/collective.cover/issues/907>`_).
   [wesleybl]
 

--- a/webpack/app/js/compose.js
+++ b/webpack/app/js/compose.js
@@ -1,5 +1,21 @@
 import ContentChooser from './contentchooser.js';
 
+/**
+ * Send a request to Plone to unlock the current cover when the user leaves the page.
+ * @param  {window#event:unload} e
+ */
+export function unlockHandler(e){
+  let compose_url = $('#contentview-compose a').attr('href');
+  // Keep _authenticator in safe_unlock_url
+  let safe_unlock_url = compose_url.replace(
+    'compose?',
+    '@@plone_lock_operations/safe_unlock?redirect:int=0&'
+  );
+  fetch(safe_unlock_url, {
+    method: 'GET', 
+    keepalive: true,
+  })
+}
 
 export default class ComposeView {
   constructor() {
@@ -7,10 +23,7 @@ export default class ComposeView {
     this.update();
     this.prepareRichText();
     new ContentChooser(this);
-
-    if (typeof(plone) !== 'undefined') {
-      $(window).unload(plone.UnlockHandler.execute);
-    }
+    window.onunload = unlockHandler;
   }
   bindEvents() {
     $(document).on('mouseover', '.sortable-tile', this.onMouseOverSortable.bind(this));

--- a/webpack/app/js/layout.js
+++ b/webpack/app/js/layout.js
@@ -1,4 +1,5 @@
 import jss from './vendor/jss.js';
+import { unlockHandler } from './compose.js';
 
 import CSSClassWidget from './cssclasswidget.js';
 
@@ -33,9 +34,7 @@ export default class LayoutView {
     this.bindEvents();
     this.init();
 
-    if (typeof(plone) !== 'undefined') {
-      $(window).unload(plone.UnlockHandler.execute);
-    }
+    window.onunload = unlockHandler;
   }
   onBeforeUnload(e) {
     let save_btn = $('#btn-save');


### PR DESCRIPTION
When an Editor enters the Compose/Layout tabs, the Cover is locked. But when the Editor exit the Compose/Layout tabs the cover was not being unlocked for the other Editors. Now the cover is unlocked.

In the Compose/Layout tabs, a request is sent to Plone to unlock the cover, in the javascript unload event, which happens when the user leaves the page.

The `plone.UnlockHandler.execute` function, which was called previously, no longer exists in Plone 5.

Fixes #916 