### PR TITLE
Fix tile selection in Layout tab when we have multiple tiles

### DIFF
--- a/webpack/app/scss/_layout.scss
+++ b/webpack/app/scss/_layout.scss
@@ -246,6 +246,11 @@ button.btn::-moz-focus-inner, input[type='submit'].btn::-moz-focus-inner {
     background: #fff;
     box-shadow: 0 0 2px 0 #888;
   }
+  #tiles-list{
+    ul{
+      flex-wrap: wrap;
+    }
+  }
 }
 
 .ui-sortable-placeholder {


### PR DESCRIPTION
When we had multiple tiles or when the screen resolution was small, the tile list was below the portlet column when there were portlets on the right. This made it impossible to select tiles from the end of the list.

With this style change, the tile list is broken into two lines, without going below the portlet column.