### PR TITLE
Shows selected folder path in Content Tree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Shows selected folder path in Content Tree (fixes `#921 <https://github.com/collective/collective.cover/issues/921>`_).
+  [wesleybl]
+
 - Add missing dependencies: ``Products.MimetypesRegistry``, ``Products.ZCatalog``,
   ``persistent``, ``plone.locking``, ``zope.container``, ``zope.traversing``, ``ZODB`` and ``Zope``.
   [wesleybl]

--- a/webpack/app/scss/_contentchooser.scss
+++ b/webpack/app/scss/_contentchooser.scss
@@ -107,9 +107,10 @@ input[type='text'] {
 
 #content-trees #general_panel {
   padding: 0;
+  display: block;
 }
 
-#contentchooser-content-search-input-container, #contentchooser-content-trees-container, .contentchooser-clear {
+#contentchooser-content-search-input-container, #contentchooser-content-trees-container, a.contentchooser-clear {
   display: inline-block;
 }
 


### PR DESCRIPTION
The fieldset that contains the path receives the `autotoc-section` class, which has the `display: none` property.

So we need to be more specific in the css selector, to put the `display: inline-block` property.

Also fixed the position of the "x" that clears the item filter.

Fixes #921 