### PR TITLE
Wait longer in editing for unlock to work

### DIFF
--- a/src/collective/cover/tests/test_cover.robot
+++ b/src/collective/cover/tests/test_cover.robot
@@ -22,7 +22,7 @@ Update
     [arguments]  ${title}  ${description}
 
     Click Link  link=Edit
-    Sleep  1s  wait for unlock to work
+    Sleep  2s  wait for unlock to work
     Input Text  css=${title_selector}  ${title}
     Input Text  css=${description_selector}  ${description}
     Click Button  Save


### PR DESCRIPTION
If editing is too fast, unlock doesn't work and it's not possible to delete the object.

This fix:

```
Page should have contained text 'has been deleted' but did not.
```

in test_cover.robot.

Fix job:

https://github.com/collective/collective.cover/runs/5855485967?check_suite_focus=true#step:12:387