### PR TITLE
Fix test tile sorting

### DIFF
--- a/src/collective/cover/tests/test_list_tile.robot
+++ b/src/collective/cover/tests/test_list_tile.robot
@@ -95,6 +95,9 @@ Test List Tile
     Drag And Drop By Offset  css=${first_item}  0  580
     Sleep  2s  Wait for reordering to occur
 
+    # Ensures sorting will be saved even after page relead.
+    Reload Page
+
     # ensure that the reordering is reflected in the DOM
     ${first_item_title} =  Get Text  css=${first_item} h2
     ${last_item_title} =  Get Text  css=${last_item} h2


### PR DESCRIPTION
In commit

https://github.com/collective/collective.cover/commit/c403cbd8dbdd87d2b1b48aa27ee4e16e92a3a3d2

the function `onStop` of `ComposeView`, has been removed to fix the drag and drop of content from one tile to another. However, it is still needed to save the position of a content, when drag and drop occurs on the same tile, for sorting within the tile.But we do a test, to make sure it will only do something, if the drag and drop is done on the same tile. Otherwise, an error occurs when moving content from one tile to another.

Fixes #925