### PR TITLE
fix "Uncaught TypeError: this.getFolderContents is not a function"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix error when clicking on a folder in Content Tree.
+  [idgserpro]
+
 - Fix error when clearing content chooser input (fixes `#942 <https://github.com/collective/collective.cover/issues/942>`_).
   [wesleybl]
 

--- a/src/collective/cover/tests/test_contentchooser.robot
+++ b/src/collective/cover/tests/test_contentchooser.robot
@@ -11,6 +11,7 @@ Suite Teardown  Close all browsers
 ${basic_tile_location}  'collective.cover.basic'
 ${file_selector}  .ui-draggable .contenttype-file
 ${document_selector}  a[title="This document was created for testing purposes : /my-document"]
+${folder_selector}  a[title="This folder was created for testing purposes"]
 ${contentchooser_search_selector}  FIXME
 ${contentchooser_search_clear}  a.contentchooser-clear
 ${contentchooser_close}  div.close
@@ -56,20 +57,11 @@ Test Content Chooser
     Click Element  css=#content-trees ${contentchooser_search_clear}
     Page Should Not Contain  1 Results
     Page Should Contain Element  css=${document_selector}
-    Input Text  css=#content-trees input  file
+    Input Text  css=#content-trees input  My folder
     Wait Until Page Contains  1 Results
-    Page Should Contain Element  css=${file_selector}
-    # TODO: Refactor this test before https://github.com/collective/collective.cover/issues/508
-    # Click Element  css=${file_selector}
-    # Wait Until Page Contains  My file
-
-    # go back to tree root
-    # Click Element  link=Plone site
-    # ${TIMEOUT} =  Get Selenium timeout
-    # ${IMPLICIT_WAIT} =  Get Selenium implicit wait
-    # Wait Until Keyword Succeeds  ${TIMEOUT}  ${IMPLICIT_WAIT}
-    # ...                          Page Should Not Contain  My file
-
-    # Click Element  css=${contentchooser_close}
-    # Wait Until Keyword Succeeds  ${TIMEOUT}  ${IMPLICIT_WAIT}
-    # ...                          Element Should Not Be Visible  css=${CONTENT_CHOOSER_SELECTOR}
+    Page Should Contain Element  css=${folder_selector}
+    Click Element  css=${folder_selector}
+    Page Should Contain  Plone site → My folder
+    Page Should Not Contain Element  css=${folder_selector}
+    Click link  Plone site
+    Page Should Contain Element  css=${folder_selector}

--- a/webpack/app/js/contentchooser.js
+++ b/webpack/app/js/contentchooser.js
@@ -374,7 +374,7 @@ export default class ContentChooser {
       mimeType: 'application/x-www-form-urlencoded',
       type: 'POST',
       data: data,
-      success: function(text) {
+      success: text => {
         $('#ajax-spinner').hide();
         let html = '';
         let data = $.parseJSON(text);


### PR DESCRIPTION
fix error "Uncaught TypeError: this.getFolderContents is not a function" when trying to open a folder in the navigation tree