### PR TITLE
Fix robot tests randomly failing

### DIFF
--- a/src/collective/cover/tests/test_basic_tile.robot
+++ b/src/collective/cover/tests/test_basic_tile.robot
@@ -137,6 +137,8 @@ Test Basic Tile
     Click Edit Cover
     Click Button  css=${save_edit_selector}
     Page Should Not Contain  There were some errors.
+    Wait For Condition  return jQuery.active == 0
+    Wait Until Page Contains  Tile saved
 
     # move to the default view and check tile persisted
     Click Link  link=View
@@ -179,7 +181,8 @@ Test Basic Tile
     Wait Until Page Contains  Edit Basic Tile
     Input Text  id=${title_field_id}  ${title_sample}
     Click Button  css=${save_edit_selector}
-    Wait Until Page Does Not Contain  Edit Basic Tile
+    Wait For Condition  return jQuery.active == 0
+    Wait Until Page Contains  Tile saved
 
     # check for successful AJAX refresh
     Wait Until Page Contains  ${title_sample}

--- a/src/collective/cover/tests/test_cover.robot
+++ b/src/collective/cover/tests/test_cover.robot
@@ -27,3 +27,4 @@ Update
     Input Text  css=${description_selector}  ${description}
     Click Button  Save
     Page Should Contain  Changes saved
+    Sleep  2s  wait for unlock to work


### PR DESCRIPTION
- Wait for tile edit popup to close before trying to click on another link. We were trying to click on the link before the popup closed, causing the error:

```
Test Basic Tile                                                       | FAIL |
  StaleElementReferenceException: Message: The element reference of <a class="" href="http://localhost:33931/plone/title-1/?_authenticator=8fe8b900ec8d49c2a19ba16dd97650a9f4309431"> is stale; either the element is no longer attached to the DOM, it is not in the current frame context, or the document has been refreshed
```

fixes #932 

- Wait a few seconds before trying to delete a cove. We are updating the content and will soon save and delete. The time
between saving and deleting was short, causing Plone to assume that the content was still locked when trying to delete. This caused the error in Plone:
```
ResourceLockedError: Object 'title-1' is locked.
```

See:

![robot_test_cover_Test_CRUD_selenium-screenshot-1](https://user-images.githubusercontent.com/3297795/216708556-a54ebb2a-4366-472d-a9b8-204035fa6544.png)


This caused the following error in test robot:

```
  ==============================================================================
  Test Cover                                                                    
  ==============================================================================
  Test CRUD                                                             | FAIL |
  Page should have contained text 'has been deleted' but did not.
  ------------------------------------------------------------------------------
  Test Cover                                                            | FAIL |
  1 critical test, 0 passed, 1 failed
  1 test total, 0 passed, 1 failed
```

Fixes: https://github.com/collective/collective.cover/actions/runs/4087391783/jobs/7048099546


