### PR TITLE
Unpinn waitress

### DIFF
--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -7,15 +7,3 @@ extends =
 
 [versions:python27]
 lazy-object-proxy = 1.6.0
-
-# FIXME: waitress = 2.1.2 fix the error:
-#     OSError: [Errno 9] Bad file descriptor
-# See: https://github.com/Pylons/waitress/issues/374
-# This error causes the server to "freeze" on robot tests and the tests never finish.
-# waitress = 2.1.2 has been pinned in Zope 4.8.2. So this pinn here should be removed
-# when Plone 5.2.9 is released.
-[versions:python37]
-waitress = 2.1.2
-
-[versions:python38]
-waitress = 2.1.2


### PR DESCRIPTION
Plone 5.2.9 has been released. So, it already pin `waitress>=2.1.2` for Python 3, no more pin needed here.