### PR TITLE
Wait a little longer before editing the content in robot test

### DIFF
--- a/src/collective/cover/tests/test_cover.robot
+++ b/src/collective/cover/tests/test_cover.robot
@@ -18,13 +18,16 @@ Test CRUD
 
 *** Keywords ***
 
+# BBB: Customization needed to avoid unlock error when we have delete content
+# right after update. Wait a few seconds before update the content.
+# Necessary only in Python 2.
+
 Update
     [arguments]  ${title}  ${description}
 
     Click Link  link=Edit
-    Sleep  2s  wait for unlock to work
+    Sleep  5s  wait for unlock to work
     Input Text  css=${title_selector}  ${title}
     Input Text  css=${description_selector}  ${description}
     Click Button  Save
     Page Should Contain  Changes saved
-    Sleep  2s  wait for unlock to work


### PR DESCRIPTION
Avoid unlock error when we have delete content right after update. Wait a few seconds before update the content. Necessary only in Python 2.

Avoid error:

```
  ==============================================================================
  Test Cover                                                                    
  ==============================================================================
  Test CRUD                                                             | FAIL |
  Page should have contained text 'has been deleted' but did not.
  ------------------------------------------------------------------------------
  Test Cover                                                            | FAIL |
  1 critical test, 0 passed, 1 failed
  1 test total, 0 passed, 1 failed
```
