### PR TITLE
Fixes robot tests that use rich text

### DIFF
--- a/src/collective/cover/tests/cover.robot
+++ b/src/collective/cover/tests/cover.robot
@@ -113,3 +113,10 @@ Close All Browsers Without Beforeunload
     ...              closing the browsers.
     Execute Javascript  window.onbeforeunload = undefined;
     Close All Browsers
+
+Input RichText
+  [Documentation]  Wait Tinymce initialize and input text in active editor.
+  [Arguments]  ${input}
+  Wait For Condition  return tinymce.activeEditor.initialized === true
+  Execute Javascript  tinyMCE.activeEditor.setContent('${input}');
+  Wait For Condition  return tinymce.activeEditor.getContent().includes('${input}')

--- a/src/collective/cover/tests/test_link_integrity.robot
+++ b/src/collective/cover/tests/test_link_integrity.robot
@@ -69,8 +69,6 @@ Edit RichText Tile
 
     Click Edit Cover
     Wait Until Page Contains  Edit Rich Text Tile
-    Sleep  1s  Wait for TinyMCE to load
-    Wait For Condition  return typeof tinyMCE !== "undefined" && tinyMCE.activeEditor !== null && document.getElementById(tinyMCE.activeEditor.id) !== null
-    Execute Javascript  tinyMCE.activeEditor.setContent('${html}');
+    Input RichText  ${html}
     Click Button  css=${save_edit_selector}
     Wait Until Page Does Not Contain  Edit Rich Text Tile

--- a/src/collective/cover/tests/test_richtext_tile.robot
+++ b/src/collective/cover/tests/test_richtext_tile.robot
@@ -39,9 +39,7 @@ Test RichText Tile
     # see: https://github.com/collective/collective.cover/issues/543
     Click Edit Cover
     Wait Until Page Contains  Edit Rich Text Tile
-    Sleep  1s  Wait for TinyMCE to load
-    Wait For Condition  return typeof tinyMCE !== "undefined" && tinyMCE.activeEditor !== null && document.getElementById(tinyMCE.activeEditor.id) !== null
-    Execute Javascript  tinyMCE.activeEditor.setContent("${text_sample}");
+    Input RichText  ${text_sample}
     Click Button  css=${save_edit_selector}
     # save via ajax => wait until the tile has been reloaded
     Wait Until Page Does Not Contain  Edit Rich Text Tile

--- a/src/collective/cover/tests/test_searchabletext_indexer.robot
+++ b/src/collective/cover/tests/test_searchabletext_indexer.robot
@@ -37,9 +37,7 @@ Test RichTextTile is Searchable
     # Add the text to the richtext tile
     Compose Cover
     Click Link  ${richtext_edit_link_selector}
-    Wait For Condition  return typeof tinyMCE !== "undefined" && tinyMCE.activeEditor !== null && document.getElementById(tinyMCE.activeEditor.id) !== null
-    Wait For Condition  return jQuery.active == 0
-    Execute Javascript  tinyMCE.activeEditor.setContent("${text}");
+    Input RichText  ${text}
     Click Button  css=${save_edit_selector}
     Wait Until Page Contains  ${text}
 


### PR DESCRIPTION
It waits that the set text is actually in the textarea, before performing new actions.

Fix error:

```
  ==============================================================================
  Test Searchabletext Indexer                                                   
  ==============================================================================
  Test RichTextTile is Searchable                                       | FAIL |
  Text 'Fahrenheit ja Celsius yrjösivät Åsan backgammon-peliin, Volkswagenissa, daiquirin ja ZX81:n yhteisvaikutuksesta.' did not appear in 30 seconds.
  ------------------------------------------------------------------------------
  Test Searchabletext Indexer                                           | FAIL |
  1 critical test, 0 passed, 1 failed
  1 test total, 0 passed, 1 failed
  ==============================================================================
```

See: https://github.com/collective/collective.cover/actions/runs/4501838184/jobs/7922806360