### PR TITLE
Fix error when clearing content chooser input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 3.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Fix error when clearing content chooser input (fixes `#942 <https://github.com/collective/collective.cover/issues/942>`_).
+  [wesleybl]
+
 - Improve content chooser search input layout.
   [wesleybl]
 

--- a/src/collective/cover/tests/test_contentchooser.robot
+++ b/src/collective/cover/tests/test_contentchooser.robot
@@ -10,6 +10,7 @@ Suite Teardown  Close all browsers
 
 ${basic_tile_location}  'collective.cover.basic'
 ${file_selector}  .ui-draggable .contenttype-file
+${document_selector}  a[title="This document was created for testing purposes : /my-document"]
 ${contentchooser_search_selector}  FIXME
 ${contentchooser_search_clear}  a.contentchooser-clear
 ${contentchooser_close}  div.close
@@ -38,10 +39,11 @@ Test Content Chooser
 
     # make a search on Recent Items
     Click Element  link=Recent Items
-    Input Text  css=#recent input  folder
-    # FIXME: we have no result counter in here
-    #Wait Until Page Contains  1 Results
+    Input Text  css=#recent input  My file
+    Wait Until Page Contains  1 Results
     Click Element  css=#recent ${contentchooser_search_clear}
+    Page Should Not Contain  1 Results
+    Page Should Contain Element  css=${document_selector}
 
     Click Element  link=Content Tree
     Wait Until Page Contains  Plone site
@@ -52,6 +54,8 @@ Test Content Chooser
 
     # navigate the tree
     Click Element  css=#content-trees ${contentchooser_search_clear}
+    Page Should Not Contain  1 Results
+    Page Should Contain Element  css=${document_selector}
     Input Text  css=#content-trees input  file
     Wait Until Page Contains  1 Results
     Page Should Contain Element  css=${file_selector}

--- a/webpack/app/js/contentchooser.js
+++ b/webpack/app/js/contentchooser.js
@@ -231,7 +231,7 @@ export default class ContentChooser {
     );
     this.filterOnKeyUp();
     $('#contentchooser-content-search #recent .item-list').on('scroll', this.onRecentScroll.bind(this));
-    $(document).on('click', '#recent .contentchooser-clear', function(e) {
+    $(document).on('click', '#recent .contentchooser-clear', e => {
       $(e.currentTarget).prev().children('input').val('');
       let url = $('#contentchooser-content-search-button').attr('data-url');
       this.ajaxSearchRequest.push($.ajax({
@@ -244,9 +244,9 @@ export default class ContentChooser {
       }));
       return false;
     });
-    $(document).on('click', '#content-trees .contentchooser-clear', function(e) {
+    $(document).on('click', '#content-trees .contentchooser-clear', e => {
       $(e.currentTarget).prev().children('input').val('');
-      this.getFolderContents(portal_url, '@@jsonbytype');
+      this.getFolderContents(this.portal_url, '@@jsonbytype');
       return false;
     });
     $('#contentchooser-content-search-button').click(function(e) {


### PR DESCRIPTION
When we cleared the filter, the contents of the previous filter and the amount of items found were still displayed.

This was due to a Javascript error. The variable `portal_url` was not defined inside the function that is called when clicking on the clear button. Then we use `this.portal_url`, to use the class variable. For `this` to be considered the class, it was necessary to use arrow functions.

Fixes #942 